### PR TITLE
✨ NEW: Add pydantic models

### DIFF
--- a/aiida_restapi/models.py
+++ b/aiida_restapi/models.py
@@ -1,24 +1,94 @@
 # -*- coding: utf-8 -*-
-"""Schemas for AiiDA REST API"""
+"""Schemas for AiiDA REST API.
+
+Models in this module mirror those in
+`aiida/backends/djsite/db/models.py` and `aiida/backends/sqlalchemy/models`
+"""
 # pylint: disable=too-few-public-methods
 
-from typing import Optional
+from datetime import datetime
+from typing import List, Optional, Type, TypeVar, ClassVar
 
 from pydantic import BaseModel, Field
 
+from aiida import orm
 
-class User(BaseModel):
-    """AiiDA User model."""
+ModelType = TypeVar("ModelType", bound="AiidaModel")
 
-    id: Optional[int] = Field(description="Unique user id (pk)")
-    first_name: Optional[str] = Field(description="First name of the user")
-    last_name: Optional[str] = Field(description="Last name of the user")
-    institution: Optional[str] = Field(
-        description="Host institution or workplace of the user"
-    )
-    email: str = Field(description="Email address of the user")
+
+class AiidaModel(BaseModel):
+    """A mapping of an AiiDA entity to a pydantic model."""
+
+    _orm_entity: ClassVar[Type[orm.entities.Entity]] = orm.entities.Entity
 
     class Config:
         """The models configuration."""
 
         orm_mode = True
+
+    @classmethod
+    def get_projectable_properties(cls) -> List[str]:
+        """Return projectable properties."""
+        return list(cls.schema()["properties"].keys())
+
+    @classmethod
+    def get_entities(
+        cls: Type[ModelType],
+        *,
+        page_size: Optional[int] = None,
+        page: int = 0,
+        project: Optional[List[str]] = None,
+        order_by: Optional[List[str]] = None,
+    ) -> List[ModelType]:
+        """Return a list of entities (with pagination).
+
+        :param project: properties to project (default: all available)
+        :param page_size: the page size (default: infinite)
+        :param page: the page to return, if page_size set
+        """
+        if project is None:
+            project = cls.get_projectable_properties()
+        else:
+            assert set(cls.get_projectable_properties()).issuperset(
+                project
+            ), f"projection not subset of projectable properties: {project!r}"
+        query = orm.QueryBuilder().append(
+            cls._orm_entity, tag="fields", project=project
+        )
+        if page_size is not None:
+            query.offset(page_size * (page - 1))
+            query.limit(page_size)
+        if order_by is not None:
+            assert set(cls.get_projectable_properties()).issuperset(
+                order_by
+            ), f"order_by not subset of projectable properties: {project!r}"
+            query.order_by({"fields": order_by})
+        return [cls(**result["fields"]) for result in query.dict()]
+
+
+class Comment(AiidaModel):
+    """AiiDA Comment model."""
+
+    _orm_entity = orm.Comment
+
+    id: Optional[int] = Field(description="Unique comment id (pk)")
+    uuid: str = Field(description="Unique comment uuid")
+    ctime: Optional[datetime] = Field(description="Creation time")
+    mtime: Optional[datetime] = Field(description="Last modification time")
+    content: Optional[str] = Field(description="Comment content")
+    dbnode_id: Optional[int] = Field(description="Unique node id (pk)")
+    user_id: Optional[int] = Field(description="Unique user id (pk)")
+
+
+class User(AiidaModel):
+    """AiiDA User model."""
+
+    _orm_entity = orm.User
+
+    id: Optional[int] = Field(description="Unique user id (pk)")
+    email: str = Field(description="Email address of the user")
+    first_name: Optional[str] = Field(description="First name of the user")
+    last_name: Optional[str] = Field(description="Last name of the user")
+    institution: Optional[str] = Field(
+        description="Host institution or workplace of the user"
+    )

--- a/aiida_restapi/models.py
+++ b/aiida_restapi/models.py
@@ -2,7 +2,7 @@
 """Schemas for AiiDA REST API.
 
 Models in this module mirror those in
-`aiida/backends/djsite/db/models.py` and `aiida/backends/sqlalchemy/models`
+`aiida.backends.djsite.db.models` and `aiida.backends.sqlalchemy.models`
 """
 # pylint: disable=too-few-public-methods
 

--- a/aiida_restapi/models.py
+++ b/aiida_restapi/models.py
@@ -7,11 +7,10 @@ Models in this module mirror those in
 # pylint: disable=too-few-public-methods
 
 from datetime import datetime
-from typing import List, Optional, Type, TypeVar, ClassVar
-
-from pydantic import BaseModel, Field
+from typing import ClassVar, List, Optional, Type, TypeVar
 
 from aiida import orm
+from pydantic import BaseModel, Field
 
 ModelType = TypeVar("ModelType", bound="AiidaModel")
 
@@ -63,7 +62,9 @@ class AiidaModel(BaseModel):
                 order_by
             ), f"order_by not subset of projectable properties: {project!r}"
             query.order_by({"fields": order_by})
-        return [cls(**result["fields"]) for result in query.dict()]
+        return [
+            cls(**result["fields"]) for result in query.dict()  # type: ignore[call-arg]
+        ]
 
 
 class Comment(AiidaModel):

--- a/aiida_restapi/models.py
+++ b/aiida_restapi/models.py
@@ -12,6 +12,7 @@ from typing import ClassVar, List, Optional, Type, TypeVar
 from aiida import orm
 from pydantic import BaseModel, Field
 
+# Template type for subclasses of `AiidaModel`
 ModelType = TypeVar("ModelType", bound="AiidaModel")
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -14,7 +14,7 @@ pytest_plugins = ["aiida.manage.tests.pytest_fixtures"]
 def clear_database_auto(clear_database_before_test):  # pylint: disable=unused-argument
     """Automatically clear database in between tests."""
 
-    # todo: Somehow this does not reset the user id counter, which causes the /users/id test to fail  # pylint: disable=fixme
+    # TODO: Somehow this does not reset the user id counter, which causes the /users/id test to fail  # pylint: disable=fixme
 
 
 @pytest.fixture(scope="function")

--- a/mypy.ini
+++ b/mypy.ini
@@ -13,4 +13,4 @@ plugins = pydantic.mypy
 init_forbid_extra = True
 init_typed = True
 warn_required_dynamic_aliases = True
-warn_untyped_fields = True
+warn_untyped_fields = False

--- a/setup.json
+++ b/setup.json
@@ -38,6 +38,7 @@
             "wheel~=0.31",
             "coverage",
             "pytest~=3.6,<5.0.0",
+            "pytest-regressions",
             "pytest-cov",
             "requests"
         ],

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,11 +1,12 @@
+# -*- coding: utf-8 -*-
 """Test that all aiida entity models can be loaded loaded into pydantic models."""
-from aiida_restapi import models
 from aiida import orm
+
+from aiida_restapi import models
 
 
 def replace_dynamic(data: dict) -> dict:
-    """Replace dynamic fields with their type name.
-    """
+    """Replace dynamic fields with their type name."""
     for key in ["id", "uuid", "dbnode_id", "user_id", "mtime", "ctime"]:
         if key in data:
             data[key] = type(data[key]).__name__
@@ -13,6 +14,7 @@ def replace_dynamic(data: dict) -> dict:
 
 
 def test_comment_get_entities(data_regression):
+    """Test ``Comment.get_entities``"""
     orm_user = orm.User(
         email="verdi@opera.net", first_name="Giuseppe", last_name="Verdi"
     ).store()
@@ -23,8 +25,7 @@ def test_comment_get_entities(data_regression):
 
 
 def test_user_get_entities(data_regression):
-    orm.User(
-        email="verdi@opera.net", first_name="Giuseppe", last_name="Verdi"
-    ).store()
+    """Test ``User.get_entities``"""
+    orm.User(email="verdi@opera.net", first_name="Giuseppe", last_name="Verdi").store()
     py_users = models.User.get_entities(order_by=["id"])
     data_regression.check([replace_dynamic(c.dict()) for c in py_users])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,30 @@
+"""Test that all aiida entity models can be loaded loaded into pydantic models."""
+from aiida_restapi import models
+from aiida import orm
+
+
+def replace_dynamic(data: dict) -> dict:
+    """Replace dynamic fields with their type name.
+    """
+    for key in ["id", "uuid", "dbnode_id", "user_id", "mtime", "ctime"]:
+        if key in data:
+            data[key] = type(data[key]).__name__
+    return data
+
+
+def test_comment_get_entities(data_regression):
+    orm_user = orm.User(
+        email="verdi@opera.net", first_name="Giuseppe", last_name="Verdi"
+    ).store()
+    orm_node = orm.Data().store()
+    orm.Comment(orm_node, orm_user, "content").store()
+    py_comments = models.Comment.get_entities(order_by=["id"])
+    data_regression.check([replace_dynamic(c.dict()) for c in py_comments])
+
+
+def test_user_get_entities(data_regression):
+    orm.User(
+        email="verdi@opera.net", first_name="Giuseppe", last_name="Verdi"
+    ).store()
+    py_users = models.User.get_entities(order_by=["id"])
+    data_regression.check([replace_dynamic(c.dict()) for c in py_users])

--- a/tests/test_models/test_comment_get_entities.yml
+++ b/tests/test_models/test_comment_get_entities.yml
@@ -1,0 +1,7 @@
+- content: content
+  ctime: datetime
+  dbnode_id: int
+  id: int
+  mtime: datetime
+  user_id: int
+  uuid: str

--- a/tests/test_models/test_user_get_entities.yml
+++ b/tests/test_models/test_user_get_entities.yml
@@ -1,0 +1,10 @@
+- email: tests@aiida.mail
+  first_name: AiiDA
+  id: int
+  institution: aiidateam
+  last_name: Plugintest
+- email: verdi@opera.net
+  first_name: Giuseppe
+  id: int
+  institution: ''
+  last_name: Verdi


### PR DESCRIPTION
Ok so this is still rough, but what I want to get some early feedback...
So I wanted to initially add a pydantic model for all the aiida models, but two things I noted straight away:

1. We should really not be using `from_orm` unless necessary, since creating ORM instances is slow, when compared to just returning the fields from the database.

@ltalirz you probably already know this, but @NinadBhat as an example:

```python
In [10]: for i in range(1000):
    ...:     orm.Dict(dict={"a": 1}).store()
    ...: 
In [11]: %%timeit
    ...: QueryBuilder().append(orm.Dict, project=["**"]).dict()
    ...: 
    ...: 
82.9 ms ± 607 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [12]: %%timeit
    ...: list(orm.Dict.objects.find())
    ...: 
    ...: 
166 ms ± 6.76 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

```

2. `from_orm` does not allow you to retrieve foreign keys, for example `dbnode_id`/`user_id` for `Comment`.

Hence I have added this base class with (thus far) a `get_entities` method to basically replicate `from_orm`. It also allows for pagination (returning only a set number of results)

Two other things to note:

1. I have added https://pytest-regressions.readthedocs.io, this is a handy pytest plugin for testing JSON type outputs
2. I've added some funky typing `TypeVar` magic, which basically makes subclasses have the correct output types; e.g. `User.get_entities` will return the `List[User]` type.

So yeh let me know your initial thoughts?