### PR TITLE
Move towards JSON API standard for responses

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,8 @@ repos:
         (?x)^(
             docs/.*|
             tests/.*|
-            conftest.py
+            conftest.py|
+            aiida_restapi/models/json_api.py
         )$
 
   - repo: https://github.com/PyCQA/pylint
@@ -51,6 +52,7 @@ repos:
       - fastapi~=0.65.1
       - uvicorn[standard]>=0.12.0,<0.14.0
       - pydantic~=1.8.2
+      - pydantic-jsonapi==0.11.0
       - python-jose
       - python-multipart
       - passlib

--- a/aiida_restapi/models/__init__.py
+++ b/aiida_restapi/models/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+"""pydantic models for AiiDA REST API.
+"""
+# pylint: disable=too-few-public-methods
+
+from .entities import *
+from .responses import *

--- a/aiida_restapi/models/entities.py
+++ b/aiida_restapi/models/entities.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Schemas for AiiDA REST API.
+"""ORM entity schemas for AiiDA REST API.
 
 Models in this module mirror those in
 `aiida.backends.djsite.db.models` and `aiida.backends.sqlalchemy.models`
@@ -11,6 +11,8 @@ from typing import ClassVar, List, Optional, Type, TypeVar
 
 from aiida import orm
 from pydantic import BaseModel, Field
+
+__all__ = ('AiidaModel', 'Comment', 'User')
 
 # Template type for subclasses of `AiidaModel`
 ModelType = TypeVar("ModelType", bound="AiidaModel")
@@ -64,7 +66,7 @@ class AiidaModel(BaseModel):
             ), f"order_by not subset of projectable properties: {project!r}"
             query.order_by({"fields": order_by})
         return [
-            cls(**result["fields"]) for result in query.dict()  # type: ignore[call-arg]
+            result["fields"] for result in query.dict()  # type: ignore[call-arg]
         ]
 
 
@@ -94,3 +96,4 @@ class User(AiidaModel):
     institution: Optional[str] = Field(
         description="Host institution or workplace of the user"
     )
+

--- a/aiida_restapi/models/entities.py
+++ b/aiida_restapi/models/entities.py
@@ -66,7 +66,7 @@ class AiidaModel(BaseModel):
             ), f"order_by not subset of projectable properties: {project!r}"
             query.order_by({"fields": order_by})
         return [
-            result["fields"] for result in query.dict()  # type: ignore[call-arg]
+            cls(**result["fields"]) for result in query.dict()  # type: ignore[call-arg]
         ]
 
 

--- a/aiida_restapi/models/json_api.py
+++ b/aiida_restapi/models/json_api.py
@@ -1,0 +1,380 @@
+"""pydantic models for JSON API v1.0
+
+Inspired by https://github.com/Materials-Consortia/optimade-python-tools/blob/master/optimade/models/jsonapi.py 
+whose goal is to reproduce the https://jsonapi.org/format/1.0/ standard.
+
+Here, we make modifications to allow deviations from the JSON API standard for backwards compatibility 
+with the aiida-core REST API. These changes are prefixed by comments starting with `# MODIFICATION:`.
+
+
+"""
+# pylint: disable=no-self-argument
+from typing import Optional, Union, List, TypeVar, Dict
+from datetime import datetime, timezone
+from pydantic import (  # pylint: disable=no-name-in-module
+    BaseModel,
+    AnyUrl,
+    parse_obj_as,
+    root_validator,
+    Field,
+)
+
+
+__all__ = (
+    "Meta",
+    "Link",
+    "JsonApi",
+    "ToplevelLinks",
+    "ErrorLinks",
+    "ErrorSource",
+    "BaseResource",
+    "RelationshipLinks",
+    "Relationship",
+    "Relationships",
+    "ResourceLinks",
+    "Attributes",
+    "Resource",
+    "Response",
+)
+
+class Meta(BaseModel):
+    """Non-standard meta-information that can not be represented as an attribute or relationship."""
+
+    class Config:
+        extra = "allow"
+
+
+class Link(BaseModel):
+    """A link **MUST** be represented as either: a string containing the link's URL or a link object."""
+
+    href: AnyUrl = Field(..., description="a string containing the link’s URL.")
+    meta: Optional[Meta] = Field(
+        None,
+        description="a meta object containing non-standard meta-information about the link.",
+    )
+
+
+class JsonApi(BaseModel):
+    """An object describing the server's implementation"""
+
+    version: str = Field(
+        default="1.0", description="Version of the json API used"
+    )
+    meta: Optional[Meta] = Field(
+        None, description="Non-standard meta information"
+    )
+
+
+class ToplevelLinks(BaseModel):
+    """A set of Links objects, possibly including pagination"""
+
+    self: Optional[Union[AnyUrl, Link]] = Field(
+        None, description="A link to itself"
+    )
+    related: Optional[Union[AnyUrl, Link]] = Field(
+        None, description="A related resource link"
+    )
+
+    # Pagination
+    first: Optional[Union[AnyUrl, Link]] = Field(
+        None, description="The first page of data"
+    )
+    last: Optional[Union[AnyUrl, Link]] = Field(
+        None, description="The last page of data"
+    )
+    prev: Optional[Union[AnyUrl, Link]] = Field(
+        None, description="The previous page of data"
+    )
+    next: Optional[Union[AnyUrl, Link]] = Field(
+        None, description="The next page of data"
+    )
+
+    @root_validator(pre=False)
+    def check_additional_keys_are_links(cls, values):
+        """The `ToplevelLinks` class allows any additional keys, as long as
+        they are also Links or Urls themselves.
+
+        """
+        for key, value in values.items():
+            if key not in cls.schema()["properties"]:
+                values[key] = parse_obj_as(Optional[Union[AnyUrl, Link]], value)
+
+        return values
+
+    class Config:
+        extra = "allow"
+
+
+class ErrorLinks(BaseModel):
+    """A Links object specific to Error objects"""
+
+    about: Optional[Union[AnyUrl, Link]] = Field(
+        None,
+        description="A link that leads to further details about this particular occurrence of the problem.",
+    )
+
+
+class ErrorSource(BaseModel):
+    """an object containing references to the source of the error"""
+
+    pointer: Optional[str] = Field(
+        None,
+        description="a JSON Pointer [RFC6901] to the associated entity in the request document "
+        '[e.g. "/data" for a primary data object, or "/data/attributes/title" for a specific attribute].',
+    )
+    parameter: Optional[str] = Field(
+        None,
+        description="a string indicating which URI query parameter caused the error.",
+    )
+
+
+class Error(BaseModel):
+    """An error response"""
+
+    id: Optional[str] = Field(
+        None,
+        description="A unique identifier for this particular occurrence of the problem.",
+    )
+    links: Optional[ErrorLinks] = Field(
+        None, description="A links object storing about"
+    )
+    status: Optional[str] = Field(
+        None,
+        description="the HTTP status code applicable to this problem, expressed as a string value.",
+    )
+    code: Optional[str] = Field(
+        None,
+        description="an application-specific error code, expressed as a string value.",
+    )
+    title: Optional[str] = Field(
+        None,
+        description="A short, human-readable summary of the problem. "
+        "It **SHOULD NOT** change from occurrence to occurrence of the problem, except for purposes of localization.",
+    )
+    detail: Optional[str] = Field(
+        None,
+        description="A human-readable explanation specific to this occurrence of the problem.",
+    )
+    source: Optional[ErrorSource] = Field(
+        None, description="An object containing references to the source of the error"
+    )
+    meta: Optional[Meta] = Field(
+        None,
+        description="a meta object containing non-standard meta-information about the error.",
+    )
+
+    def __hash__(self):
+        return hash(self.json())
+
+
+class BaseResource(BaseModel):
+    """Minimum requirements to represent a Resource"""
+
+    id: str = Field(..., description="Resource ID")
+
+    # MODIFICATION: Currently not provided by AiiDA REST API
+    # type: str = Field(..., description="Resource type")
+    #
+    # class Config:
+    #     @staticmethod
+    #     def schema_extra(schema: Dict[str, Any], model: Type["BaseResource"]) -> None:
+    #         """Ensure `id` and `type` are the first two entries in the list required properties.
+
+    #         Note:
+    #             This _requires_ that `id` and `type` are the _first_ model fields defined
+    #             for all sub-models of `BaseResource`.
+
+    #         """
+    #         if "id" not in schema.get("required", []):
+    #             schema["required"] = ["id"] + schema.get("required", [])
+    #         if "type" not in schema.get("required", []):
+    #             required = []
+    #             for field in schema.get("required", []):
+    #                 required.append(field)
+    #                 if field == "id":
+    #                     # To make sure the property order match the listed properties,
+    #                     # this ensures "type" is added immediately after "id".
+    #                     required.append("type")
+    #             schema["required"] = required
+
+
+class RelationshipLinks(BaseModel):
+    """A resource object **MAY** contain references to other resource objects ("relationships").
+    Relationships may be to-one or to-many.
+    Relationships can be specified by including a member in a resource's links object.
+
+    """
+
+    self: Optional[Union[AnyUrl, Link]] = Field(
+        None,
+        description="""A link for the relationship itself (a 'relationship link').
+This link allows the client to directly manipulate the relationship.
+When fetched successfully, this link returns the [linkage](https://jsonapi.org/format/1.0/#document-resource-object-linkage) for the related resources as its primary data.
+(See [Fetching Relationships](https://jsonapi.org/format/1.0/#fetching-relationships).)""",
+    )
+    related: Optional[Union[AnyUrl, Link]] = Field(
+        None,
+        description="A [related resource link](https://jsonapi.org/format/1.0/#document-resource-object-related-resource-links).",
+    )
+
+    @root_validator(pre=True)
+    def either_self_or_related_must_be_specified(cls, values):
+        for value in values.values():
+            if value is not None:
+                break
+        else:
+            raise ValueError(
+                "Either 'self' or 'related' MUST be specified for RelationshipLinks"
+            )
+        return values
+
+
+class Relationship(BaseModel):
+    """Representation references from the resource object in which it’s defined to other resource objects."""
+
+    links: Optional[RelationshipLinks] = Field(
+        None,
+        description="a links object containing at least one of the following: self, related",
+    )
+    data: Optional[Union[BaseResource, List[BaseResource]]] = Field(
+        None, description="Resource linkage"
+    )
+    meta: Optional[Meta] = Field(
+        None,
+        description="a meta object that contains non-standard meta-information about the relationship.",
+    )
+
+    @root_validator(pre=True)
+    def at_least_one_relationship_key_must_be_set(cls, values):
+        for value in values.values():
+            if value is not None:
+                break
+        else:
+            raise ValueError(
+                "Either 'links', 'data', or 'meta' MUST be specified for Relationship"
+            )
+        return values
+
+
+class Relationships(BaseModel):
+    """
+    Members of the relationships object (\"relationships\") represent references from the resource object in which it's defined to other resource objects.
+    Keys MUST NOT be:
+        type
+        id
+    """
+
+    @root_validator(pre=True)
+    def check_illegal_relationships_fields(cls, values):
+        illegal_fields = ("id", "type")
+        for field in illegal_fields:
+            if field in values:
+                raise ValueError(
+                    f"{illegal_fields} MUST NOT be fields under Relationships"
+                )
+        return values
+
+
+class ResourceLinks(BaseModel):
+    """A Resource Links object"""
+
+    self: Optional[Union[AnyUrl, Link]] = Field(
+        None,
+        description="A link that identifies the resource represented by the resource object.",
+    )
+
+
+class Attributes(BaseModel):
+    """
+    Members of the attributes object ("attributes\") represent information about the resource object in which it's defined.
+    The keys for Attributes MUST NOT be:
+        relationships
+        links
+        id
+        type
+    """
+
+    class Config:
+        extra = "allow"
+
+    @root_validator(pre=True)
+    def check_illegal_attributes_fields(cls, values):
+        illegal_fields = ("relationships", "links", "id", "type")
+        for field in illegal_fields:
+            if field in values:
+                raise ValueError(
+                    f"{illegal_fields} MUST NOT be fields under Attributes"
+                )
+        return values
+
+
+class Resource(BaseResource):
+    """Resource objects appear in a JSON API document to represent resources."""
+
+    links: Optional[ResourceLinks] = Field(
+        None, description="a links object containing links related to the resource."
+    )
+    meta: Optional[Meta] = Field(
+        None,
+        description="a meta object containing non-standard meta-information about a resource that can not be represented as an attribute or relationship.",
+    )
+    attributes: Optional[Attributes] = Field(
+        None,
+        description="an attributes object representing some of the resource’s data.",
+    )
+    relationships: Optional[Relationships] = Field(
+        None,
+        description="""[Relationships object](https://jsonapi.org/format/1.0/#document-resource-object-relationships)
+describing relationships between the resource and other JSON API resources.""",
+    )
+    
+    # MODIFICATION: AiiDA REST API puts fields directly at the top level
+    class Config:
+        extra = "allow"
+
+
+class Response(BaseModel):
+    """A top-level response"""
+
+    data: Optional[Union[None, Resource, List[Resource]]] = Field(
+        None, description="Outputted Data", uniqueItems=True
+    )
+    meta: Optional[Meta] = Field(
+        None,
+        description="A meta object containing non-standard information related to the Success",
+    )
+    errors: Optional[List[Error]] = Field(
+        None, description="A list of unique errors", uniqueItems=True
+    )
+    included: Optional[List[Resource]] = Field(
+        None, description="A list of unique included resources", uniqueItems=True
+    )
+    links: Optional[ToplevelLinks] = Field(
+        None, description="Links associated with the primary data or errors"
+    )
+    jsonapi: Optional[JsonApi] = Field(
+        None, description="Information about the JSON API used"
+    )
+
+    @root_validator(pre=True)
+    def either_data_meta_or_errors_must_be_set(cls, values):
+        required_fields = ("data", "meta", "errors")
+        if not any(values.get(field) for field in required_fields):
+            raise ValueError(
+                f"At least one of {required_fields} MUST be specified in the top-level response"
+            )
+        return values
+
+    class Config:
+        """The specification mandates that datetimes must be encoded following
+        [RFC3339](https://tools.ietf.org/html/rfc3339), which does not support
+        fractional seconds, thus they must be stripped in the response. This can
+        cause issues when the underlying database contains fields that do include
+        microseconds, as filters may return unexpected results.
+        """
+
+        json_encoders = {
+            datetime: lambda v: v.astimezone(timezone.utc).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            ),
+        }

--- a/aiida_restapi/models/json_api.py
+++ b/aiida_restapi/models/json_api.py
@@ -13,21 +13,21 @@ from pydantic_jsonapi.relationships import ResponseRelationshipsType
 from pydantic_jsonapi.resource_links import ResourceLinks
 
 # TypeT = TypeVar('TypeT', bound=str)
-AttributesT = TypeVar("AttributesT")
+# AttributesT = TypeVar("AttributesT")
 
 
-class ResponseDataModel(GenericModel, Generic[AttributesT]):
+# class ResponseDataModel(GenericModel):
 
-    id: str
-    relationships: Optional[ResponseRelationshipsType]
-    links: Optional[ResourceLinks]
+#     id: str
+#     relationships: Optional[ResponseRelationshipsType]
+#     links: Optional[ResourceLinks]
 
-    class Config:
-        validate_all = True
-        extra = "allow"  # added
+#     class Config:
+#         validate_all = True
+#         extra = "allow"  # added
 
 
-DataT = TypeVar("DataT", bound=ResponseDataModel)
+DataT = TypeVar("DataT")  # , bound=ResponseDataModel)
 
 
 class ResponseModel(GenericModel, Generic[DataT]):
@@ -51,7 +51,7 @@ class ResponseModel(GenericModel, Generic[DataT]):
         attributes: Optional[dict] = None,
         relationships: Optional[dict] = None,
         links: Optional[dict] = None,
-    ) -> ResponseDataModel:
+    ) -> DataT:
         data_type = get_type_hints(cls)["data"]
         if getattr(data_type, "__origin__", None) is list:
             data_type = data_type.__args__[0]

--- a/aiida_restapi/models/json_api.py
+++ b/aiida_restapi/models/json_api.py
@@ -1,380 +1,65 @@
-"""pydantic models for JSON API v1.0
+# -*- coding: utf-8 -*-
+"""Adapted JSON API models.
 
-Inspired by https://github.com/Materials-Consortia/optimade-python-tools/blob/master/optimade/models/jsonapi.py 
-whose goal is to reproduce the https://jsonapi.org/format/1.0/ standard.
-
-Here, we make modifications to allow deviations from the JSON API standard for backwards compatibility 
-with the aiida-core REST API. These changes are prefixed by comments starting with `# MODIFICATION:`.
-
-
+Adapting pydantic_jsonapi.response to fit the non-compliant AiiDA REST API responses.
+Changes made as comments.
 """
-# pylint: disable=no-self-argument
-from typing import Optional, Union, List, TypeVar, Dict
-from datetime import datetime, timezone
-from pydantic import (  # pylint: disable=no-name-in-module
-    BaseModel,
-    AnyUrl,
-    parse_obj_as,
-    root_validator,
-    Field,
-)
+# pylint: disable=missing-class-docstring,redefined-builtin,missing-function-docstring,too-few-public-methods
+from typing import Generic, Optional, TypeVar, get_type_hints
+
+from pydantic.generics import GenericModel
+from pydantic_jsonapi.filter import filter_none
+from pydantic_jsonapi.relationships import ResponseRelationshipsType
+from pydantic_jsonapi.resource_links import ResourceLinks
+
+# TypeT = TypeVar('TypeT', bound=str)
+AttributesT = TypeVar("AttributesT")
 
 
-__all__ = (
-    "Meta",
-    "Link",
-    "JsonApi",
-    "ToplevelLinks",
-    "ErrorLinks",
-    "ErrorSource",
-    "BaseResource",
-    "RelationshipLinks",
-    "Relationship",
-    "Relationships",
-    "ResourceLinks",
-    "Attributes",
-    "Resource",
-    "Response",
-)
+class ResponseDataModel(GenericModel, Generic[AttributesT]):
 
-class Meta(BaseModel):
-    """Non-standard meta-information that can not be represented as an attribute or relationship."""
+    id: str
+    relationships: Optional[ResponseRelationshipsType]
+    links: Optional[ResourceLinks]
 
     class Config:
-        extra = "allow"
+        validate_all = True
+        extra = "allow"  # added
 
 
-class Link(BaseModel):
-    """A link **MUST** be represented as either: a string containing the link's URL or a link object."""
-
-    href: AnyUrl = Field(..., description="a string containing the link’s URL.")
-    meta: Optional[Meta] = Field(
-        None,
-        description="a meta object containing non-standard meta-information about the link.",
-    )
+DataT = TypeVar("DataT", bound=ResponseDataModel)
 
 
-class JsonApi(BaseModel):
-    """An object describing the server's implementation"""
+class ResponseModel(GenericModel, Generic[DataT]):
 
-    version: str = Field(
-        default="1.0", description="Version of the json API used"
-    )
-    meta: Optional[Meta] = Field(
-        None, description="Non-standard meta information"
-    )
+    data: DataT
+    included: Optional[list]
+    meta: Optional[dict]
+    links: Optional[ResourceLinks]
 
+    def dict(self, *, serlialize_none: bool = False, **kwargs):
+        response = super().dict(**kwargs)
+        if serlialize_none:
+            return response
+        return filter_none(response)
 
-class ToplevelLinks(BaseModel):
-    """A set of Links objects, possibly including pagination"""
-
-    self: Optional[Union[AnyUrl, Link]] = Field(
-        None, description="A link to itself"
-    )
-    related: Optional[Union[AnyUrl, Link]] = Field(
-        None, description="A related resource link"
-    )
-
-    # Pagination
-    first: Optional[Union[AnyUrl, Link]] = Field(
-        None, description="The first page of data"
-    )
-    last: Optional[Union[AnyUrl, Link]] = Field(
-        None, description="The last page of data"
-    )
-    prev: Optional[Union[AnyUrl, Link]] = Field(
-        None, description="The previous page of data"
-    )
-    next: Optional[Union[AnyUrl, Link]] = Field(
-        None, description="The next page of data"
-    )
-
-    @root_validator(pre=False)
-    def check_additional_keys_are_links(cls, values):
-        """The `ToplevelLinks` class allows any additional keys, as long as
-        they are also Links or Urls themselves.
-
-        """
-        for key, value in values.items():
-            if key not in cls.schema()["properties"]:
-                values[key] = parse_obj_as(Optional[Union[AnyUrl, Link]], value)
-
-        return values
-
-    class Config:
-        extra = "allow"
-
-
-class ErrorLinks(BaseModel):
-    """A Links object specific to Error objects"""
-
-    about: Optional[Union[AnyUrl, Link]] = Field(
-        None,
-        description="A link that leads to further details about this particular occurrence of the problem.",
-    )
-
-
-class ErrorSource(BaseModel):
-    """an object containing references to the source of the error"""
-
-    pointer: Optional[str] = Field(
-        None,
-        description="a JSON Pointer [RFC6901] to the associated entity in the request document "
-        '[e.g. "/data" for a primary data object, or "/data/attributes/title" for a specific attribute].',
-    )
-    parameter: Optional[str] = Field(
-        None,
-        description="a string indicating which URI query parameter caused the error.",
-    )
-
-
-class Error(BaseModel):
-    """An error response"""
-
-    id: Optional[str] = Field(
-        None,
-        description="A unique identifier for this particular occurrence of the problem.",
-    )
-    links: Optional[ErrorLinks] = Field(
-        None, description="A links object storing about"
-    )
-    status: Optional[str] = Field(
-        None,
-        description="the HTTP status code applicable to this problem, expressed as a string value.",
-    )
-    code: Optional[str] = Field(
-        None,
-        description="an application-specific error code, expressed as a string value.",
-    )
-    title: Optional[str] = Field(
-        None,
-        description="A short, human-readable summary of the problem. "
-        "It **SHOULD NOT** change from occurrence to occurrence of the problem, except for purposes of localization.",
-    )
-    detail: Optional[str] = Field(
-        None,
-        description="A human-readable explanation specific to this occurrence of the problem.",
-    )
-    source: Optional[ErrorSource] = Field(
-        None, description="An object containing references to the source of the error"
-    )
-    meta: Optional[Meta] = Field(
-        None,
-        description="a meta object containing non-standard meta-information about the error.",
-    )
-
-    def __hash__(self):
-        return hash(self.json())
-
-
-class BaseResource(BaseModel):
-    """Minimum requirements to represent a Resource"""
-
-    id: str = Field(..., description="Resource ID")
-
-    # MODIFICATION: Currently not provided by AiiDA REST API
-    # type: str = Field(..., description="Resource type")
-    #
-    # class Config:
-    #     @staticmethod
-    #     def schema_extra(schema: Dict[str, Any], model: Type["BaseResource"]) -> None:
-    #         """Ensure `id` and `type` are the first two entries in the list required properties.
-
-    #         Note:
-    #             This _requires_ that `id` and `type` are the _first_ model fields defined
-    #             for all sub-models of `BaseResource`.
-
-    #         """
-    #         if "id" not in schema.get("required", []):
-    #             schema["required"] = ["id"] + schema.get("required", [])
-    #         if "type" not in schema.get("required", []):
-    #             required = []
-    #             for field in schema.get("required", []):
-    #                 required.append(field)
-    #                 if field == "id":
-    #                     # To make sure the property order match the listed properties,
-    #                     # this ensures "type" is added immediately after "id".
-    #                     required.append("type")
-    #             schema["required"] = required
-
-
-class RelationshipLinks(BaseModel):
-    """A resource object **MAY** contain references to other resource objects ("relationships").
-    Relationships may be to-one or to-many.
-    Relationships can be specified by including a member in a resource's links object.
-
-    """
-
-    self: Optional[Union[AnyUrl, Link]] = Field(
-        None,
-        description="""A link for the relationship itself (a 'relationship link').
-This link allows the client to directly manipulate the relationship.
-When fetched successfully, this link returns the [linkage](https://jsonapi.org/format/1.0/#document-resource-object-linkage) for the related resources as its primary data.
-(See [Fetching Relationships](https://jsonapi.org/format/1.0/#fetching-relationships).)""",
-    )
-    related: Optional[Union[AnyUrl, Link]] = Field(
-        None,
-        description="A [related resource link](https://jsonapi.org/format/1.0/#document-resource-object-related-resource-links).",
-    )
-
-    @root_validator(pre=True)
-    def either_self_or_related_must_be_specified(cls, values):
-        for value in values.values():
-            if value is not None:
-                break
-        else:
-            raise ValueError(
-                "Either 'self' or 'related' MUST be specified for RelationshipLinks"
-            )
-        return values
-
-
-class Relationship(BaseModel):
-    """Representation references from the resource object in which it’s defined to other resource objects."""
-
-    links: Optional[RelationshipLinks] = Field(
-        None,
-        description="a links object containing at least one of the following: self, related",
-    )
-    data: Optional[Union[BaseResource, List[BaseResource]]] = Field(
-        None, description="Resource linkage"
-    )
-    meta: Optional[Meta] = Field(
-        None,
-        description="a meta object that contains non-standard meta-information about the relationship.",
-    )
-
-    @root_validator(pre=True)
-    def at_least_one_relationship_key_must_be_set(cls, values):
-        for value in values.values():
-            if value is not None:
-                break
-        else:
-            raise ValueError(
-                "Either 'links', 'data', or 'meta' MUST be specified for Relationship"
-            )
-        return values
-
-
-class Relationships(BaseModel):
-    """
-    Members of the relationships object (\"relationships\") represent references from the resource object in which it's defined to other resource objects.
-    Keys MUST NOT be:
-        type
-        id
-    """
-
-    @root_validator(pre=True)
-    def check_illegal_relationships_fields(cls, values):
-        illegal_fields = ("id", "type")
-        for field in illegal_fields:
-            if field in values:
-                raise ValueError(
-                    f"{illegal_fields} MUST NOT be fields under Relationships"
-                )
-        return values
-
-
-class ResourceLinks(BaseModel):
-    """A Resource Links object"""
-
-    self: Optional[Union[AnyUrl, Link]] = Field(
-        None,
-        description="A link that identifies the resource represented by the resource object.",
-    )
-
-
-class Attributes(BaseModel):
-    """
-    Members of the attributes object ("attributes\") represent information about the resource object in which it's defined.
-    The keys for Attributes MUST NOT be:
-        relationships
-        links
-        id
-        type
-    """
-
-    class Config:
-        extra = "allow"
-
-    @root_validator(pre=True)
-    def check_illegal_attributes_fields(cls, values):
-        illegal_fields = ("relationships", "links", "id", "type")
-        for field in illegal_fields:
-            if field in values:
-                raise ValueError(
-                    f"{illegal_fields} MUST NOT be fields under Attributes"
-                )
-        return values
-
-
-class Resource(BaseResource):
-    """Resource objects appear in a JSON API document to represent resources."""
-
-    links: Optional[ResourceLinks] = Field(
-        None, description="a links object containing links related to the resource."
-    )
-    meta: Optional[Meta] = Field(
-        None,
-        description="a meta object containing non-standard meta-information about a resource that can not be represented as an attribute or relationship.",
-    )
-    attributes: Optional[Attributes] = Field(
-        None,
-        description="an attributes object representing some of the resource’s data.",
-    )
-    relationships: Optional[Relationships] = Field(
-        None,
-        description="""[Relationships object](https://jsonapi.org/format/1.0/#document-resource-object-relationships)
-describing relationships between the resource and other JSON API resources.""",
-    )
-    
-    # MODIFICATION: AiiDA REST API puts fields directly at the top level
-    class Config:
-        extra = "allow"
-
-
-class Response(BaseModel):
-    """A top-level response"""
-
-    data: Optional[Union[None, Resource, List[Resource]]] = Field(
-        None, description="Outputted Data", uniqueItems=True
-    )
-    meta: Optional[Meta] = Field(
-        None,
-        description="A meta object containing non-standard information related to the Success",
-    )
-    errors: Optional[List[Error]] = Field(
-        None, description="A list of unique errors", uniqueItems=True
-    )
-    included: Optional[List[Resource]] = Field(
-        None, description="A list of unique included resources", uniqueItems=True
-    )
-    links: Optional[ToplevelLinks] = Field(
-        None, description="Links associated with the primary data or errors"
-    )
-    jsonapi: Optional[JsonApi] = Field(
-        None, description="Information about the JSON API used"
-    )
-
-    @root_validator(pre=True)
-    def either_data_meta_or_errors_must_be_set(cls, values):
-        required_fields = ("data", "meta", "errors")
-        if not any(values.get(field) for field in required_fields):
-            raise ValueError(
-                f"At least one of {required_fields} MUST be specified in the top-level response"
-            )
-        return values
-
-    class Config:
-        """The specification mandates that datetimes must be encoded following
-        [RFC3339](https://tools.ietf.org/html/rfc3339), which does not support
-        fractional seconds, thus they must be stripped in the response. This can
-        cause issues when the underlying database contains fields that do include
-        microseconds, as filters may return unexpected results.
-        """
-
-        json_encoders = {
-            datetime: lambda v: v.astimezone(timezone.utc).strftime(
-                "%Y-%m-%dT%H:%M:%SZ"
-            ),
-        }
+    @classmethod
+    def resource_object(
+        cls,
+        *,
+        id: str,
+        attributes: Optional[dict] = None,
+        relationships: Optional[dict] = None,
+        links: Optional[dict] = None,
+    ) -> ResponseDataModel:
+        data_type = get_type_hints(cls)["data"]
+        if getattr(data_type, "__origin__", None) is list:
+            data_type = data_type.__args__[0]
+        typename = get_type_hints(data_type)["type"].__args__[0]
+        return data_type(
+            id=id,
+            type=typename,
+            attributes=attributes or {},
+            relationships=relationships,
+            links=links,
+        )

--- a/aiida_restapi/models/responses.py
+++ b/aiida_restapi/models/responses.py
@@ -23,17 +23,13 @@ def EntityResponse(
     use_list: bool = False,
 ) -> Type[json_api.ResponseModel]:
     """Returns entity-specif pydantic response model."""
-    response_data_model = json_api.ResponseDataModel[
-        # Literal[type_string],
-        attributes_model,
-    ]
+    response_data_model = attributes_model
     type_string = (
         attributes_model._orm_entity.__name__.lower()  # pylint: disable=protected-access
     )
     if use_list:
-        response_data_model = List[response_data_model]
         response_data_model.__name__ = f"ListResponseData[{type_string}]"
-        response_model = json_api.ResponseModel[response_data_model]
+        response_model = json_api.ResponseModel[List[response_data_model]]
         response_model.__name__ = f"ListResponse[{type_string}]"
     else:
         response_data_model.__name__ = f"ResponseData[{type_string}]"

--- a/aiida_restapi/models/responses.py
+++ b/aiida_restapi/models/responses.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""Response schemas for AiiDA REST API.
+
+Builds upon response schemas from `json_api` module.
+"""
+# pylint: disable=too-few-public-methods
+
+from pydantic import Field
+from typing import TypeVar, List, Generic
+
+from pydantic.main import BaseModel
+
+from .entities import AiidaModel
+from . import json_api
+
+__all__ = ('Response',)
+
+ModelType = TypeVar("ModelType", bound="AiidaModel")
+
+class _Response(json_api.Response, Generic[ModelType]):
+    """Template model for successful REST API responses."""
+    data: ModelType = Field(description="List of requested data")
+
+def Response(resource_model: ModelType, use_list: bool = False):
+    """Returns response model for specific resource.
+
+    Use e.g. as follows::
+
+        Response(User)
+        Response(User, use_list=True)
+    
+    """
+    if use_list:
+        resource_model = List[resource_model]
+
+    return _Response[resource_model]
+
+
+# class ResponseError(Response):
+#     """errors MUST be present and data MUST be skipped"""
+
+#     errors: List[json_api.Error] = Field(
+#         ...,
+#         description="A list of error objects.",
+#         uniqueItems=True,
+#     )
+
+#     @root_validator(pre=True)
+#     def data_must_be_skipped(cls, values):
+#         if values.get("data", None) is not None:
+#             raise ValueError("data MUST be skipped for failures reporting errors")
+#         return values

--- a/aiida_restapi/routers/users.py
+++ b/aiida_restapi/routers/users.py
@@ -2,22 +2,30 @@
 """Declaration of FastAPI application."""
 from typing import List, Optional
 
+from fastapi import APIRouter, Depends, Request
 from aiida import orm
 from aiida.cmdline.utils.decorators import with_dbenv
 from fastapi import APIRouter, Depends
 
-from aiida_restapi.models import User
+from aiida_restapi.models import Response, User
 
 from .auth import get_current_active_user
 
 router = APIRouter()
 
+UserResponse = Response(User)
+UsersResponse = Response(User, use_list=True)
+UsersResponse.update_forward_refs()
 
-@router.get("/users", response_model=List[User])
+@router.get('/users', response_model=UsersResponse)
 @with_dbenv()
-async def read_users() -> List[User]:
+async def read_users() -> UsersResponse:
     """Get list of all users"""
-    return [User.from_orm(u) for u in orm.User.objects.find()]
+    #print(User.get_entities())
+    #print(UserResponse({'data':User.get_entities()}))
+    print(User.get_entities())
+    return {'data' : User.get_entities() }
+    #return UsersResponse(data=User.get_entities())
 
 
 @router.get("/users/{user_id}", response_model=User)

--- a/aiida_restapi/routers/users.py
+++ b/aiida_restapi/routers/users.py
@@ -1,52 +1,50 @@
 # -*- coding: utf-8 -*-
 """Declaration of FastAPI application."""
-from typing import List, Optional
-
-from fastapi import APIRouter, Depends, Request
 from aiida import orm
 from aiida.cmdline.utils.decorators import with_dbenv
+from aiida.common.exceptions import NotExistent
 from fastapi import APIRouter, Depends
+from fastapi.exceptions import HTTPException
 
-from aiida_restapi.models import Response, User
+from aiida_restapi.models import EntityResponse, User
 
 from .auth import get_current_active_user
 
+__all__ = ("router",)
+
 router = APIRouter()
 
-UserResponse = Response(User)
-UsersResponse = Response(User, use_list=True)
-UsersResponse.update_forward_refs()
+SingleUserResponse = EntityResponse(User)
+ManyUserResponse = EntityResponse(User, use_list=True)
 
-@router.get('/users', response_model=UsersResponse)
+
+@router.get("/users", response_model=ManyUserResponse)
 @with_dbenv()
-async def read_users() -> UsersResponse:
+async def read_users() -> ManyUserResponse:
     """Get list of all users"""
-    #print(User.get_entities())
-    #print(UserResponse({'data':User.get_entities()}))
-    print(User.get_entities())
-    return {'data' : User.get_entities() }
-    #return UsersResponse(data=User.get_entities())
+    return ManyUserResponse(data=User.get_entities())
 
 
-@router.get("/users/{user_id}", response_model=User)
+@router.get("/users/{user_id}", response_model=SingleUserResponse)
 @with_dbenv()
-async def read_user(user_id: int) -> Optional[User]:
+async def read_user(user_id: int) -> SingleUserResponse:
     """Get user by id."""
-    orm_user = orm.User.objects.get(id=user_id)
+    try:
+        orm_user = orm.User.objects.get(id=user_id)
+    except NotExistent as exc:
+        raise HTTPException(status_code=404, detail="User not found") from exc
 
-    if orm_user:
-        return User.from_orm(orm_user)
-
-    return None
+    return SingleUserResponse(user=User.from_orm(orm_user))
 
 
-@router.post("/users", response_model=User)
+@router.post("/users", response_model=SingleUserResponse)
+@with_dbenv()
 async def create_user(
     user: User,
     current_user: User = Depends(
         get_current_active_user
     ),  # pylint: disable=unused-argument
-) -> User:
+) -> SingleUserResponse:
     """Create new AiiDA user."""
     orm_user = orm.User(**user.dict(exclude_unset=True)).store()
-    return User.from_orm(orm_user)
+    return SingleUserResponse(data=User.from_orm(orm_user))

--- a/setup.json
+++ b/setup.json
@@ -31,7 +31,7 @@
         "fastapi~=0.65.1",
         "uvicorn[standard]>=0.12.0,<0.14.0",
         "pydantic~=1.8.2",
-        "pydantic-jsonapi~=0.11.0"
+        "pydantic-jsonapi==0.11.0"
     ],
     "extras_require": {
         "testing": [

--- a/setup.json
+++ b/setup.json
@@ -30,7 +30,8 @@
         "sqlalchemy<1.4",
         "fastapi~=0.65.1",
         "uvicorn[standard]>=0.12.0,<0.14.0",
-        "pydantic~=1.8.2"
+        "pydantic~=1.8.2",
+        "pydantic-jsonapi~=0.11.0"
     ],
     "extras_require": {
         "testing": [

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -8,7 +8,7 @@ def test_get_single_user(default_users, client):  # pylint: disable=unused-argum
     """Test retrieving a single user."""
     response = client.get("/users/1")
     assert response.status_code == 200
-    assert response.json()["first_name"] == "Giuseppe"
+    assert response.json()["data"]["first_name"] == "Giuseppe"
 
 
 def test_get_users(default_users, client):  # pylint: disable=unused-argument
@@ -19,7 +19,7 @@ def test_get_users(default_users, client):  # pylint: disable=unused-argument
     """
     response = client.get("/users")
     assert response.status_code == 200
-    assert len(response.json()) == 2 + 1
+    assert len(response.json()["data"]) == 2 + 1
 
 
 def test_create_user(client, authenticate):  # pylint: disable=unused-argument
@@ -30,5 +30,5 @@ def test_create_user(client, authenticate):  # pylint: disable=unused-argument
     assert response.status_code == 200, response.content
 
     response = client.get("/users")
-    first_names = [user["first_name"] for user in response.json()]
+    first_names = [user["first_name"] for user in response.json()["data"]]
     assert "New" in first_names


### PR DESCRIPTION
Start moving towards the [JSON API](https://jsonapi.org/) standard for responses of the API.

In particular, the actual data is now returned in a `data` field.

We are not fully adopting the JSON API standard here just yet, since the responses of the aiida-core REST API are not fully compatible. 

aiida-core REST API example:
```json
{
  "data": {
    "nodes  ": [
      {
        "ctime": "Sun, 21 Jul 2019 11:45:52 GMT",
        "full_type": "data.dict.Dict.|",
        "id": 102618,
        "label": "",
        "mtime": "Sun, 21 Jul 2019 11:45:52 GMT",
        "node_type": "data.dict.Dict.",
        "process_type": null,
        "user_id": 4,
        "uuid": "a43596fe-3d95-4d9b-b34a-acabc21d7a1e"
      }
    ]
  },
}
```

How a JSON API conforming response would look like
```json
{
  "data": {
    "nodes  ": [
      {
        "type": "node",
         "id": 102618,       
          "attributes": {
            "ctime": "Sun, 21 Jul 2019 11:45:52 GMT",
            "full_type": "data.dict.Dict.|",
            "label": "",
            "mtime": "Sun, 21 Jul 2019 11:45:52 GMT",
            "node_type": "data.dict.Dict.",
            "process_type": null,
            "user_id": 4,
            "uuid": "a43596fe-3d95-4d9b-b34a-acabc21d7a1e"
         }
      }
    ]
  },
}
```
