### PR TITLE
DevOps: Add AiiDA deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
             env:
                 # show timings of tests
                 PYTEST_ADDOPTS: "--durations=0"
+                AIIDA_WARN_v3: true
             run: pytest --cov aiida_restapi --cov-report=xml
 
         -   name: Upload to Codecov

--- a/aiida_restapi/graphql/orm_factories.py
+++ b/aiida_restapi/graphql/orm_factories.py
@@ -59,7 +59,7 @@ def field_names_from_orm(cls: Type[orm.Entity]) -> Set[str]:
 
 def get_projection(
     db_fields: Set[str], info: gr.ResolveInfo, is_link: bool = False
-) -> List[str]:
+) -> Union[List[str], str]:
     """Traverse the child AST to work out what fields we should project.
 
     Any fields found that are not database fields, are assumed to be joins.
@@ -69,7 +69,7 @@ def get_projection(
     """
     if is_link:
         # TODO here we need to look deeper under the "node" field
-        return ["**"]
+        return "**"
     try:
         selected = set(selected_field_names_naive(info.field_asts[0].selection_set))
         fields = db_fields.intersection(selected)
@@ -78,7 +78,7 @@ def get_projection(
             fields.add("id")
         return list(fields)
     except NotImplementedError:
-        return ["**"]
+        return "**"
 
 
 def single_cls_factory(
@@ -114,7 +114,7 @@ def create_query_path(
         leaf_kwargs[f'with_{parent["edge_type"]}'] = parent["edge_type"]
         if parent.get("project_edge"):
             leaf_kwargs["edge_tag"] = f'{parent["edge_type"]}_edge'
-            leaf_kwargs["edge_project"] = ["**"]
+            leaf_kwargs["edge_project"] = "**"
     return leaf_kwargs
 
 

--- a/aiida_restapi/routers/computers.py
+++ b/aiida_restapi/routers/computers.py
@@ -35,7 +35,7 @@ async def read_computer(comp_id: int) -> Optional[Computer]:
     """Get computer by id."""
     qbobj = QueryBuilder()
     qbobj.append(
-        orm.Computer, filters={"id": comp_id}, project=["**"], tag="computer"
+        orm.Computer, filters={"id": comp_id}, project="**", tag="computer"
     ).limit(1)
 
     return qbobj.dict()[0]["computer"]

--- a/aiida_restapi/routers/groups.py
+++ b/aiida_restapi/routers/groups.py
@@ -34,9 +34,9 @@ async def read_group(group_id: int) -> Optional[Group]:
     """Get group by id."""
     qbobj = orm.QueryBuilder()
 
-    qbobj.append(
-        orm.Group, filters={"id": group_id}, project=["**"], tag="group"
-    ).limit(1)
+    qbobj.append(orm.Group, filters={"id": group_id}, project="**", tag="group").limit(
+        1
+    )
     return qbobj.dict()[0]["group"]
 
 

--- a/aiida_restapi/routers/nodes.py
+++ b/aiida_restapi/routers/nodes.py
@@ -35,10 +35,7 @@ async def get_nodes_projectable_properties() -> List[str]:
 async def read_node(nodes_id: int) -> Optional[models.Node]:
     """Get nodes by id."""
     qbobj = orm.QueryBuilder()
-
-    qbobj.append(orm.Node, filters={"id": nodes_id}, project=["**"], tag="node").limit(
-        1
-    )
+    qbobj.append(orm.Node, filters={"id": nodes_id}, project="**", tag="node").limit(1)
     return qbobj.dict()[0]["node"]
 
 

--- a/aiida_restapi/routers/process.py
+++ b/aiida_restapi/routers/process.py
@@ -69,7 +69,7 @@ async def read_process(proc_id: int) -> Optional[Process]:
     """Get process by id."""
     qbobj = QueryBuilder()
     qbobj.append(
-        orm.ProcessNode, filters={"id": proc_id}, project=["**"], tag="process"
+        orm.ProcessNode, filters={"id": proc_id}, project="**", tag="process"
     ).limit(1)
 
     return qbobj.dict()[0]["process"]

--- a/aiida_restapi/routers/users.py
+++ b/aiida_restapi/routers/users.py
@@ -33,7 +33,7 @@ async def get_users_projectable_properties() -> List[str]:
 async def read_user(user_id: int) -> Optional[User]:
     """Get user by id."""
     qbobj = QueryBuilder()
-    qbobj.append(orm.User, filters={"id": user_id}, project=["**"], tag="user").limit(1)
+    qbobj.append(orm.User, filters={"id": user_id}, project="**", tag="user").limit(1)
 
     return qbobj.dict()[0]["user"]
 

--- a/docs/source/user_guide/tutorial.md
+++ b/docs/source/user_guide/tutorial.md
@@ -147,7 +147,7 @@ After retrieving the UUIDs, the process is submitted at `/processes` endpoint as
    ```json
    {
       "label": "report_process",
-      "process_entry_point": "aiida.calculations:arithmetic.add",
+      "process_entry_point": "aiida.calculations:core.arithmetic.add",
       "inputs": {
          "code.uuid": "e590fff6-46e3-4983-bb2b-1f4a335c5836",
          "x.uuid": "4a1a5e4c-e6ea-4a85-b407-4989a292b442",
@@ -165,7 +165,7 @@ After retrieving the UUIDs, the process is submitted at `/processes` endpoint as
       "id": 64,
       "uuid": "6bc238e2-0dec-4449-bbe0-3cf181df00eb",
       "node_type": "process.calculation.calcjob.CalcJobNode.",
-      "process_type": "aiida.calculations:arithmetic.add",
+      "process_type": "aiida.calculations:core.arithmetic.add",
       "label": "",
       "description": "job submission with the adding processes",
       "ctime": "2021-08-14T13:41:39.823818+00:00",
@@ -193,7 +193,7 @@ Response Body:
    "id": 64,
    "uuid": "6bc238e2-0dec-4449-bbe0-3cf181df00eb",
    "node_type": "process.calculation.calcjob.CalcJobNode.",
-   "process_type": "aiida.calculations:arithmetic.add",
+   "process_type": "aiida.calculations:core.arithmetic.add",
    "label": "",
    "description": "job submission with the adding processes",
    "ctime": "2021-08-14T23:41:39.823818+10:00",
@@ -206,7 +206,7 @@ Response Body:
          "plugin": "1.6.4"
       },
    ...
-      "parser_name": "arithmetic.add",
+      "parser_name": "core.arithmetic.add",
       "prepend_text": "",
       "process_label": "ArithmeticAddCalculation",
       "process_state": "created",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,8 @@ testing = [
 'data.core.list.List.|'  = 'aiida_restapi.models:Node_Post'
 'data.core.dict.Dict.|' = 'aiida_restapi.models:Node_Post'
 'data.core.singlefile.SingleFileData.|' = 'aiida_restapi.models:Node_Post'
-'data.core.code.Code.|' = 'aiida_restapi.models:Node_Post'
+'data.core.code.installed.InstalledCode.|' = 'aiida_restapi.models:Node_Post'
+'data.core.code.portable.PortableCode.|' = 'aiida_restapi.models:Node_Post'
 
 [tool.flit.module]
 name = 'aiida_restapi'
@@ -120,6 +121,7 @@ ignore-imports = 'yes'
 [tool.pytest.ini_options]
 python_files = 'test_*.py example_*.py'
 filterwarnings = [
+    'ignore:Creating AiiDA configuration folder.*:UserWarning',
     'ignore::DeprecationWarning:aiida:',
     'ignore::DeprecationWarning:plumpy:',
     'ignore::DeprecationWarning:django:',

--- a/tests/test_graphql/test_nodes.py
+++ b/tests/test_graphql/test_nodes.py
@@ -51,7 +51,7 @@ def test_node_incoming(create_node, orm_regression):
         ("incoming1", LinkType.INPUT_CALC, "link1"),
         ("incoming2", LinkType.INPUT_CALC, "link2"),
     ]:
-        node.add_incoming(create_node(label=label), link_type, link_label)
+        node.base.links.add_incoming(create_node(label=label), link_type, link_label)
     node.store()
 
     schema = create_schema([NodeQueryPlugin])
@@ -71,7 +71,7 @@ def test_node_outgoing(create_node, orm_regression):
         ("outgoing2", LinkType.CREATE, "link2"),
     ]:
         outgoing = create_node(label=label)
-        outgoing.add_incoming(node, link_type, link_label)
+        outgoing.base.links.add_incoming(node, link_type, link_label)
         outgoing.store()
 
     schema = create_schema([NodeQueryPlugin])
@@ -90,7 +90,7 @@ def test_node_ancestors(create_node, orm_regression):
         ("incoming1", LinkType.INPUT_CALC, "link1"),
         ("incoming2", LinkType.INPUT_CALC, "link2"),
     ]:
-        node.add_incoming(create_node(label=label), link_type, link_label)
+        node.base.links.add_incoming(create_node(label=label), link_type, link_label)
     node.store()
 
     schema = create_schema([NodeQueryPlugin])
@@ -109,7 +109,7 @@ def test_node_descendants(create_node, orm_regression):
         ("outgoing2", LinkType.CREATE, "link2"),
     ]:
         outgoing = create_node(label=label)
-        outgoing.add_incoming(node, link_type, link_label)
+        outgoing.base.links.add_incoming(node, link_type, link_label)
         outgoing.store()
 
     schema = create_schema([NodeQueryPlugin])

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -64,9 +64,9 @@ def test_create_code(
         response = client.post(
             "/nodes",
             json={
-                "node_type": "data.core.code.Code.|",
+                "node_type": "data.core.code.installed.InstalledCode.|",
                 "dbcomputer_id": comp_id,
-                "attributes": {"is_local": False, "remote_exec_path": "/bin/true"},
+                "attributes": {"filepath_executable": "/bin/true"},
                 "label": "test_code",
             },
         )
@@ -283,9 +283,9 @@ def test_create_additional_attribute(
             "/nodes",
             json={
                 "uuid": "3",
-                "node_type": "data.core.code.Code.|",
+                "node_type": "data.core.code.installed.InstalledCode.|",
                 "dbcomputer_id": comp_id,
-                "attributes": {"is_local": False, "remote_exec_path": "/bin/true"},
+                "attributes": {"filepath_executable": "/bin/true"},
                 "label": "test_code",
             },
         )

--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -53,7 +53,7 @@ def test_add_process(
         "/processes",
         json={
             "label": "test_new_process",
-            "process_entry_point": "aiida.calculations:arithmetic.add",
+            "process_entry_point": "aiida.calculations:core.arithmetic.add",
             "inputs": {
                 "code.uuid": code_id,
                 "x.uuid": x_id,
@@ -99,7 +99,7 @@ def test_add_process_invalid_node_id(
         "/processes",
         json={
             "label": "test_new_process",
-            "process_entry_point": "aiida.calculations:arithmetic.add",
+            "process_entry_point": "aiida.calculations:core.arithmetic.add",
             "inputs": {
                 "code.uuid": code_id,
                 "x.uuid": x_id,


### PR DESCRIPTION
The warnings are enabled by setting the `AIIDA_WARN_v3` environment variable to `True` in the CI workflow.

Most of the warnings are addressed, but a few remain that cannot be trivially fixed:

 * The `id` property on the `aiida.orm.Entity` class is deprecated. This is being called because the ORM proxy model declares `id` as the primary key field. This is correct for the database models of the `PsqlDosBackend` in `aiida-core`, but the front-end ORM is using the `pk` property instead.
 * The `attributes`, `extras` and `repository_metadata` of the proxy models are declared "top-level" and so `pydantic` will set them on the ORM instance using that property, however, these properties have been deprecated in `aiida-core` and should be set through the `base.attributes.set_many`, `base.extras.set_many` and the `base.repository.metadata` properties instead.

With the current setup using `pydantic` it is not clear how these changes can be addressed and whether the manner in which field values are being set on the underlying ORM model instance can be customized.