### PR TITLE
POST `/nodes`: Fix error message for unknown entry point

### DIFF
--- a/aiida_restapi/routers/nodes.py
+++ b/aiida_restapi/routers/nodes.py
@@ -95,7 +95,8 @@ def _get_entry_point(group: str, name: str) -> EntryPoint:
     )
     if not eps:
         raise HTTPException(
-            status_code=404, detail="Entry point '{name}' not found in group '{group}'."
+            status_code=404,
+            detail=f"Entry point '{name}' not found in group '{group}'.",
         )
     if len(eps) > 1 and len(set(ep.value for ep in eps)) != 1:
         raise HTTPException(

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -273,6 +273,24 @@ def test_wrong_entry_point(client, authenticate):  # pylint: disable=unused-argu
     assert response.status_code == 404, response.content
 
 
+def test_create_unknown_entry_point(
+    default_computers, client, authenticate
+):  # pylint: disable=unused-argument
+    """Test error message when specifying unknown ``node_type``."""
+    response = client.post(
+        "/nodes",
+        json={
+            "node_type": "data.core.Unknown.|",
+            "label": "test_code",
+        },
+    )
+    assert response.status_code == 404, response.content
+    assert (
+        response.json()["detail"]
+        == "Entry point 'data.core.Unknown.|' not found in group 'aiida.rest.post'."
+    )
+
+
 def test_create_additional_attribute(
     default_computers, client, authenticate
 ):  # pylint: disable=unused-argument


### PR DESCRIPTION
The error message contained placeholders but these were not substituted.