### PR TITLE
POST `/nodes`: Remove custom entry point group

### DIFF
--- a/docs/source/user_guide/tutorial.md
+++ b/docs/source/user_guide/tutorial.md
@@ -45,9 +45,8 @@ import requests
 url = 'http://localhost:8000/api/v4/endpoint'
 
 body = {
-   "node_type": "data.int.Int.|",
+   "node_type": "core.int",
    "attributes": {"value": 6},
-   "label": "test_Int_1"
 }
 
 response = requests.post(url, data=body)
@@ -65,11 +64,10 @@ Request URL: http://127.0.0.1:8000/nodes
 Request Body:
 ```json
 {
-   "node_type": "data.code.Code.|",
+   "node_type": "core.code.installed",
    "dbcomputer_id": 2,
    "attributes": {
-      "is_local": false,
-      "remote_exec_path": "/bin/true"
+      "filepath_executable": "/bin/true"
    },
    "label": "test_code"
 }
@@ -80,7 +78,7 @@ Response Body:
 {
    "id": 62,
    "uuid": "e590fff6-46e3-4983-bb2b-1f4a335c5836",
-   "node_type": "data.code.Code.",
+   "node_type": "data.core.code.installed.InstalledCode.",
    "process_type": null,
    "label": "test_code",
    "description": "",
@@ -89,8 +87,7 @@ Response Body:
    "user_id": 1,
    "dbcomputer_id": null,
    "attributes": {
-      "is_local": false,
-      "remote_exec_path": "/bin/true"
+      "filepath_executable": "/bin/true"
    },
    "extras": {
       "_aiida_hash": "72864a25c6ebf290a12d522b8819fb858788bf81730e934dc95ca7a1ff8cce5c"
@@ -107,9 +104,8 @@ Request URL: http://127.0.0.1:8000/nodes
 Request Body:
 ```json
 {
-   "node_type": "data.int.Int.|",
+   "node_type": "core.int",
    "attributes": {"value": 6},
-   "label": "test_Int_1"
 }
 ```
 
@@ -118,9 +114,8 @@ Response Body:
 {
    "id": 63,
    "uuid": "4a1a5e4c-e6ea-4a85-b407-4989a292b442",
-   "node_type": "data.int.Int.",
+   "node_type": "data.core.int.Int.",
    "process_type": null,
-   "label": "test_Int_1",
    "description": "",
    "ctime": "2021-08-14T13:31:40.565835+00:00",
    "mtime": "2021-08-14T13:31:40.802201+00:00",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,22 +64,6 @@ testing = [
     'requests',
 ]
 
-[project.entry-points.'aiida.cmdline.data']
-'restapi' = 'aiida_restapi.cli:data_cli'
-
-[project.entry-points.'aiida.rest.post']
-'data.core.str.Str.|' = 'aiida_restapi.models:Node_Post'
-'data.core.float.Float.|' = 'aiida_restapi.models:Node_Post'
-'data.core.int.Int.|' = 'aiida_restapi.models:Node_Post'
-'data.core.bool.Bool.|' = 'aiida_restapi.models:Node_Post'
-'data.core.structure.StructureData.|' = 'aiida_restapi.models:Node_Post'
-'data.core.orbital.OrbitalData.|' = 'aiida_restapi.models:Node_Post'
-'data.core.list.List.|'  = 'aiida_restapi.models:Node_Post'
-'data.core.dict.Dict.|' = 'aiida_restapi.models:Node_Post'
-'data.core.singlefile.SingleFileData.|' = 'aiida_restapi.models:Node_Post'
-'data.core.code.installed.InstalledCode.|' = 'aiida_restapi.models:Node_Post'
-'data.core.code.portable.PortableCode.|' = 'aiida_restapi.models:Node_Post'
-
 [tool.flit.module]
 name = 'aiida_restapi'
 
@@ -93,9 +77,6 @@ exclude = [
     '.pre-commit-config.yaml',
     '.readthedocs.yml',
     'codecov.yml',
-    'conftest.py',
-    'mypy.ini',
-    'tox.ini',
 ]
 
 [tool.isort]

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -47,7 +47,7 @@ def test_create_dict(client, authenticate):  # pylint: disable=unused-argument
     response = client.post(
         "/nodes",
         json={
-            "node_type": "data.core.dict.Dict.|",
+            "entry_point": "core.dict",
             "attributes": {"x": 1, "y": 2},
             "label": "test_dict",
         },
@@ -64,7 +64,7 @@ def test_create_code(
         response = client.post(
             "/nodes",
             json={
-                "node_type": "data.core.code.installed.InstalledCode.|",
+                "entry_point": "core.code.installed",
                 "dbcomputer_id": comp_id,
                 "attributes": {"filepath_executable": "/bin/true"},
                 "label": "test_code",
@@ -78,7 +78,7 @@ def test_create_list(client, authenticate):  # pylint: disable=unused-argument
     response = client.post(
         "/nodes",
         json={
-            "node_type": "data.core.list.List.|",
+            "entry_point": "core.list",
             "attributes": {"list": [2, 3]},
         },
     )
@@ -91,7 +91,7 @@ def test_create_int(client, authenticate):  # pylint: disable=unused-argument
     response = client.post(
         "/nodes",
         json={
-            "node_type": "data.core.int.Int.|",
+            "entry_point": "core.int",
             "attributes": {"value": 6},
         },
     )
@@ -103,7 +103,7 @@ def test_create_float(client, authenticate):  # pylint: disable=unused-argument
     response = client.post(
         "/nodes",
         json={
-            "node_type": "data.core.float.Float.|",
+            "entry_point": "core.float",
             "attributes": {"value": 6.6},
         },
     )
@@ -115,7 +115,7 @@ def test_create_string(client, authenticate):  # pylint: disable=unused-argument
     response = client.post(
         "/nodes",
         json={
-            "node_type": "data.core.str.Str.|",
+            "entry_point": "core.str",
             "attributes": {"value": "test_string"},
         },
     )
@@ -127,7 +127,7 @@ def test_create_bool(client, authenticate):  # pylint: disable=unused-argument
     response = client.post(
         "/nodes",
         json={
-            "node_type": "data.core.bool.Bool.|",
+            "entry_point": "core.bool",
             "attributes": {"value": "True"},
         },
     )
@@ -139,7 +139,7 @@ def test_create_structure_data(client, authenticate):  # pylint: disable=unused-
     response = client.post(
         "/nodes",
         json={
-            "node_type": "data.core.structure.StructureData.|",
+            "entry_point": "core.structure",
             "process_type": None,
             "description": "",
             "attributes": {
@@ -161,7 +161,7 @@ def test_create_orbital_data(client, authenticate):  # pylint: disable=unused-ar
     response = client.post(
         "/nodes",
         json={
-            "node_type": "data.core.orbital.OrbitalData.|",
+            "entry_point": "core.orbital",
             "process_type": None,
             "description": "",
             "attributes": {
@@ -201,7 +201,7 @@ def test_create_single_file_upload(
         )
     }
     params = {
-        "node_type": "data.core.singlefile.SingleFileData.|",
+        "entry_point": "core.singlefile",
         "process_type": None,
         "description": "Testing single upload file",
         "attributes": {},
@@ -219,7 +219,7 @@ def test_create_node_wrong_value(
     response = client.post(
         "/nodes",
         json={
-            "node_type": "data.core.float.Float.|",
+            "entry_point": "core.float",
             "attributes": {"value": "tests"},
         },
     )
@@ -228,7 +228,7 @@ def test_create_node_wrong_value(
     response = client.post(
         "/nodes",
         json={
-            "node_type": "data.core.int.Int.|",
+            "entry_point": "core.int",
             "attributes": {"value": "tests"},
         },
     )
@@ -242,40 +242,28 @@ def test_create_node_wrong_attribute(
     response = client.post(
         "/nodes",
         json={
-            "node_type": "data.core.str.Str.|",
+            "entry_point": "core.str",
             "attributes": {"value1": 5},
         },
     )
     assert response.status_code == 400, response.content
 
 
-def test_wrong_entry_point(client, authenticate):  # pylint: disable=unused-argument
-    """Test adding node with wrong entry point."""
-    response = client.post(
-        "/nodes",
-        json={
-            "node_type": "data.core.float.wrong.|",
-            "attributes": {"value": 3},
-        },
-    )
-    assert response.status_code == 404, response.content
-
-
 def test_create_unknown_entry_point(
     default_computers, client, authenticate
 ):  # pylint: disable=unused-argument
-    """Test error message when specifying unknown ``node_type``."""
+    """Test error message when specifying unknown ``entry_point``."""
     response = client.post(
         "/nodes",
         json={
-            "node_type": "data.core.Unknown.|",
+            "entry_point": "core.not.existing.entry.point",
             "label": "test_code",
         },
     )
     assert response.status_code == 404, response.content
     assert (
         response.json()["detail"]
-        == "Entry point 'data.core.Unknown.|' not found in group 'aiida.rest.post'."
+        == "Entry point 'core.not.existing.entry.point' not found in group 'aiida.data'"
     )
 
 
@@ -289,7 +277,7 @@ def test_create_additional_attribute(
             "/nodes",
             json={
                 "uuid": "3",
-                "node_type": "data.core.code.installed.InstalledCode.|",
+                "entry_point": "core.code.installed",
                 "dbcomputer_id": comp_id,
                 "attributes": {"filepath_executable": "/bin/true"},
                 "label": "test_code",
@@ -305,7 +293,7 @@ def test_create_bool_with_extra(
     response = client.post(
         "/nodes",
         json={
-            "node_type": "data.core.bool.Bool.|",
+            "entry_point": "core.bool",
             "attributes": {"value": "True"},
             "extras": {"extra_one": "value_1", "extra_two": "value_2"},
         },


### PR DESCRIPTION
The POST `/nodes` end point was relying on a custom entry point group `aiida.rest.post` which registered the `aiida_restapi.models:Node_Post` class under a number of entry points. The entry point names correspond to the `node_type` attributes that are automatically generated and set on instance of AiiDA `Node` ORM instances.

Not only were the entry points essentially pointless, since they all load the same class, which can simply be imported since it is a class provided by `aiida-restapi` itself, it also restricted to what `Node` types could be constructed. If a particular plugin was not present in the `aiida.rest.post` entry point group, the POST request would return a 404 error.

Instead, we should simply reuse the unique naming scheme that already exists in `aiida-core` which is to use existing entry point names for `Node` plugins, which are provided in the `aiida.data` entry point group. The `aiida.rest.post` entry point group is removed and the endpoint now requires the `entry_point` field instead of the `node_type`. The `entry_point` is loaded using tools from `aiida-core` and a 404 is returned if the entry point does not exist on the server.

If the entry point can be loaded, the corresponding class is instantiated. AiiDA's ORM will automatically set the correct `node_type` through this manner. This now means in principle that any entry point that is registered on the server can be constructed through the end point.