### PR TITLE
Add the `/daemon` endpoint.

### DIFF
--- a/aiida_restapi/main.py
+++ b/aiida_restapi/main.py
@@ -3,11 +3,12 @@
 from fastapi import FastAPI
 
 from aiida_restapi.graphql import main
-from aiida_restapi.routers import auth, computers, groups, nodes, process, users
+from aiida_restapi.routers import auth, computers, daemon, groups, nodes, process, users
 
 app = FastAPI()
 app.include_router(auth.router)
 app.include_router(computers.router)
+app.include_router(daemon.router)
 app.include_router(nodes.router)
 app.include_router(groups.router)
 app.include_router(users.router)

--- a/aiida_restapi/routers/daemon.py
+++ b/aiida_restapi/routers/daemon.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+"""Declaration of FastAPI router for daemon endpoints."""
+from __future__ import annotations
+
+import typing as t
+
+from aiida.cmdline.utils.decorators import with_dbenv
+from aiida.engine.daemon.client import DaemonException, get_daemon_client
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from ..models import User
+from .auth import get_current_active_user
+
+router = APIRouter()
+
+
+class DaemonStatusModel(BaseModel):
+    """Response model for daemon status."""
+
+    running: bool = Field(description="Whether the daemon is running or not.")
+    num_workers: t.Optional[int] = Field(
+        description="The number of workers if the daemon is running."
+    )
+
+
+@router.get("/daemon/status", response_model=DaemonStatusModel)
+@with_dbenv()
+async def get_daemon_status() -> DaemonStatusModel:
+    """Return the daemon status."""
+    client = get_daemon_client()
+
+    if not client.is_daemon_running:
+        return DaemonStatusModel(running=False, num_workers=None)
+
+    response = client.get_numprocesses()
+
+    return DaemonStatusModel(running=True, num_workers=response["numprocesses"])
+
+
+@router.post("/daemon/start", response_model=DaemonStatusModel)
+@with_dbenv()
+async def get_daemon_start(
+    current_user: User = Depends(
+        get_current_active_user
+    ),  # pylint: disable=unused-argument
+) -> DaemonStatusModel:
+    """Start the daemon."""
+    client = get_daemon_client()
+
+    if client.is_daemon_running:
+        raise HTTPException(status_code=400, detail="The daemon is already running.")
+
+    try:
+        client.start_daemon()
+    except DaemonException as exception:
+        raise HTTPException(status_code=500, detail=str(exception)) from exception
+
+    response = client.get_numprocesses()
+
+    return DaemonStatusModel(running=True, num_workers=response["numprocesses"])
+
+
+@router.post("/daemon/stop", response_model=DaemonStatusModel)
+@with_dbenv()
+async def get_daemon_stop(
+    current_user: User = Depends(
+        get_current_active_user
+    ),  # pylint: disable=unused-argument
+) -> DaemonStatusModel:
+    """Stop the daemon."""
+    client = get_daemon_client()
+
+    if not client.is_daemon_running:
+        raise HTTPException(status_code=400, detail="The daemon is not running.")
+
+    try:
+        client.stop_daemon()
+    except DaemonException as exception:
+        raise HTTPException(status_code=500, detail=str(exception)) from exception
+
+    return DaemonStatusModel(running=False, num_workers=None)

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""Test the /daemon endpoint"""
+import pytest
+from fastapi.testclient import TestClient
+
+from aiida_restapi import app
+
+client = TestClient(app)
+
+
+@pytest.mark.usefixtures("stopped_daemon_client", "authenticate")
+def test_status_and_start():
+    """Test ``/daemon/status`` when the daemon is not running and ``/daemon/start``."""
+    response = client.get("/daemon/status")
+    assert response.status_code == 200, response.content
+
+    results = response.json()
+    assert results["running"] is False
+    assert results["num_workers"] is None
+
+    response = client.post("/daemon/start")
+    assert response.status_code == 200, response.content
+
+    results = response.json()
+    assert results["running"] is True
+    assert results["num_workers"] == 1
+
+    response = client.post("/daemon/start")
+    assert response.status_code == 400, response.content
+
+
+@pytest.mark.usefixtures("started_daemon_client", "authenticate")
+def test_status_and_stop():
+    """Test ``/daemon/status`` when the daemon is running and ``/daemon/stop``."""
+    response = client.get("/daemon/status")
+    assert response.status_code == 200, response.content
+
+    results = response.json()
+    assert results["running"] is True
+    assert results["num_workers"] == 1
+
+    response = client.post("/daemon/stop")
+    assert response.status_code == 200, response.content
+
+    results = response.json()
+    assert results["running"] is False
+    assert results["num_workers"] is None
+
+    response = client.post("/daemon/stop")
+    assert response.status_code == 400, response.content


### PR DESCRIPTION
This new endpoint allows to control the daemon and offers:

 * `/daemon/status`: Return the status of the daemon
 * `/daemon/start`: Start the daemon if it is not already
 * `/daemon/stop`: Stop the daemon if it is running