### PR TITLE
Add the `/processes/outputs` end point

### DIFF
--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -147,3 +147,14 @@ def test_add_process_nested_inputs(
         },
     )
     assert response.status_code == 200
+
+
+def test_process_outputs(arithmetic_add_process, client):
+    """Test the ``/processes/outputs`` end-point."""
+    process_pk = arithmetic_add_process.pk
+    outputs = arithmetic_add_process.get_outgoing().nested()
+
+    response = client.get(f"/processes/outputs/{process_pk}")
+    results = response.json()
+    assert response.status_code == 200
+    assert sorted(results.keys()) == sorted(list(outputs.keys()))


### PR DESCRIPTION
This end-point takes a process id and returns the outputs of the corresponding `ProcessNode`. For `CalculationNodes`, the created outputs (linked through `LinkType.CREATE`) are returned, whereas for `WorkflowNodes` the returned outputs (linked through `LinkType.RETURN`) are returned.