### PR TITLE
update example

### DIFF
--- a/examples/daemon_management/script.py
+++ b/examples/daemon_management/script.py
@@ -103,12 +103,12 @@ def main():
         click.echo(f"The daemon is currently running with {num_workers} workers")
 
         click.echo("Stopping the daemon.")
-        response = request("daemon/stop", method="GET")
+        response = request("daemon/stop", method="POST")
 
     else:
         click.echo("The daemon is currently not running.")
         click.echo("Starting the daemon.")
-        response = request("daemon/start", method="GET")
+        response = request("daemon/start", method="POST")
         num_workers = response["num_workers"]
         click.echo(f"The daemon is currently running with {num_workers} workers")
 

--- a/examples/submit_quantumespresso_pw/script.py
+++ b/examples/submit_quantumespresso_pw/script.py
@@ -239,7 +239,7 @@ def main(workchain):
     structure_uuid = create_node("core.structure", structure)
     parameters_uuid = create_node("core.dict", parameters)
     kpoints_uuid = create_node("core.array.kpoints", kpoints)
-    pseudo_si_uuid = get_pseudo_for_element("SSSP/1.1/PBE/efficiency", "Si")["uuid"]
+    pseudo_si_uuid = get_pseudo_for_element("SSSP/1.2/PBE/efficiency", "Si")["uuid"]
 
     if workchain:
         # Inputs for a ``PwBaseWorkChain`` to compute SCF of Si crystal structure


### PR DESCRIPTION
I run the scripts in the example folder. Two of them failed, and they need to be updated.

I got this error when committing new changes:
```
[extras.pipfile_deprecated_finder.2] 'pip-shims<=0.3.4' does not match '^[a-zA-Z-_.0-9]+$'
```
It's likely due the the `isort` package. I update its version to `5.12.0` and there is no more error.