### PR TITLE
Dependencies: Update pre-commit requirement `isort==5.12.0`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: check-yaml
 
   - repo: https://github.com/pycqa/isort
-    rev: '5.8.0'
+    rev: '5.12.0'
     hooks:
     - id: isort
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,11 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: '3.11'
+
 python:
-  version: 3.8
   install:
   - method: pip
     path: .

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -67,7 +67,6 @@ pygments_style = "sphinx"
 html_theme = "sphinx_book_theme"
 html_theme_options = {
     "home_page_in_toc": True,
-    "extra_navbar": "",
     "show_navbar_depth": 2,
     "path_to_docs": "docs/source",
 }

--- a/tests/test_graphql/test_users/test_users.yml
+++ b/tests/test_graphql/test_users/test_users.yml
@@ -2,11 +2,11 @@ data:
   users:
     count: 3
     rows:
-    - email: tests@aiida.mail
-      first_name: AiiDA
+    - email: test@aiida.local
+      first_name: ''
       id: int
-      institution: aiidateam
-      last_name: Plugintest
+      institution: ''
+      last_name: ''
     - email: a@b.com
       first_name: ''
       id: int

--- a/tests/test_models/test_user_get_entities.yml
+++ b/tests/test_models/test_user_get_entities.yml
@@ -1,8 +1,8 @@
-- email: tests@aiida.mail
-  first_name: AiiDA
+- email: test@aiida.local
+  first_name: ''
   id: int
-  institution: aiidateam
-  last_name: Plugintest
+  institution: ''
+  last_name: ''
 - email: verdi@opera.net
   first_name: Giuseppe
   id: int


### PR DESCRIPTION
Older versions were breaking due to a release of `poetry-core` causing our pre-commit job in the CI to fail. For details, see: https://github.com/PyCQA/isort/issues/2077