### PR TITLE
Devops: Add Codecov token to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,4 +72,5 @@ jobs:
                 name: pytests
                 flags: pytests
                 file: ./coverage.xml
+                token: ${{ secrets.CODECOV_TOKEN }}
                 fail_ci_if_error: true


### PR DESCRIPTION
After merge got this error
```shell
Error: Codecov: Failed to properly create commit: The process '/home/runner/work/_actions/codecov/codecov-action/v4/dist/codecov' failed with exit code 1
```
https://github.com/aiidateam/aiida-restapi/actions/runs/9188834086/job/25269509068

Not sure why this did not appear during PR. Hope this fixes it

EDIT:
I see it did not fail because of 
> Tokenless uploading is unsupported. However, PRs made from forks to the upstream public repos will support tokenless (e.g. contributors to OS projects do not need the upstream repo's Codecov token). For details, [see our docs](https://docs.codecov.com/docs/codecov-uploader#supporting-token-less-uploads-for-forks-of-open-source-repos-using-codecov)

https://github.com/codecov/codecov-action?tab=readme-ov-file#breaking-changes
I will create nonupstream branch to test

EDIT2:
Okay with this PR https://github.com/aiidateam/aiida-restapi/pull/68 we can verify that the fix works. As it is a branch on the upstream repository it fails when the token is commented out (see second commit that fails while first commit works)