### PR TITLE
Devops: Add codecov token to CI [From upstream]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,4 +72,5 @@ jobs:
                 name: pytests
                 flags: pytests
                 file: ./coverage.xml
+                token: ${{ secrets.CODECOV_TOKEN }}
                 fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,5 +72,5 @@ jobs:
                 name: pytests
                 flags: pytests
                 file: ./coverage.xml
-                token: ${{ secrets.CODECOV_TOKEN }}
+                # token: ${{ secrets.CODECOV_TOKEN }}
                 fail_ci_if_error: true


### PR DESCRIPTION
Duplicate of PR https://github.com/aiidateam/aiida-restapi/pull/67 because it seems that I cannot test if the other PR fixes the issue since is it is from a fork

> Tokenless uploading is unsupported. However, PRs made from forks to the upstream public repos will support tokenless (e.g. contributors to OS projects do not need the upstream repo's Codecov token). For details, [see our docs](https://docs.codecov.com/docs/codecov-uploader#supporting-token-less-uploads-for-forks-of-open-source-repos-using-codecov)

https://github.com/codecov/codecov-action?tab=readme-ov-file#breaking-changes