### PR TITLE
Implement `nodes/{node_id}/download` endpoint

### DIFF
--- a/aiida_restapi/config.py
+++ b/aiida_restapi/config.py
@@ -17,3 +17,6 @@ fake_users_db = {
         'disabled': False,
     }
 }
+
+# The chunks size for streaming data for download
+DOWNLOAD_CHUNK_SIZE = 1024

--- a/docs/source/user_guide/graphql.md
+++ b/docs/source/user_guide/graphql.md
@@ -508,6 +508,10 @@ http://localhost:5000/api/v4/nodes/ffe11/repo/list
 ```html
 http://localhost:5000/api/v4/nodes/ffe11/repo/contents?filename="aiida.in"
 ```
+
+
+Not implemented for GraphQL, please use the REST API for this use case.
+
 ```html
 http://localhost:5000/api/v4/nodes/fafdsf/download?download_format=xsf
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,8 @@ testing = [
   'pytest-regressions',
   'pytest-cov',
   'requests',
-  'httpx'
+  'httpx',
+  'numpy~=1.21'
 ]
 
 [project.urls]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import tempfile
 from datetime import datetime
 from typing import Any, Callable, Mapping, MutableMapping, Optional, Union
 
+import numpy as np
 import pytest
 import pytz
 from aiida import orm
@@ -162,6 +163,17 @@ def default_nodes():
     node_4 = orm.Bool(False).store()
 
     return [node_1.pk, node_2.pk, node_3.pk, node_4.pk]
+
+
+@pytest.fixture(scope='function')
+def array_data_node():
+    """Populate database with downloadable node (implmenting a _prepare_* function).
+    For testing the chunking of the streaming we create an array that needs to be splitted int two chunks."""
+
+    from aiida_restapi.config import DOWNLOAD_CHUNK_SIZE
+
+    nb_elements = DOWNLOAD_CHUNK_SIZE // 64 + 1
+    return orm.ArrayData(np.arange(nb_elements, dtype=np.int64)).store()
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
We implement the download of nodes that implement the export
functionality as in aiida-core. We use StreamingResponse to send the
data in byte chunks of size 1024.

The tests require the client to be asynchronously to prevent I/O
operations on closed file handlers.

We require a numpy dependency because we need a node type that
implemented the export functionality. The only node type that is not
bounded to the domain of material science is ArrayData.