### PR TITLE
Migrating to latest aiida: pydantic 2, graphene 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
         steps:
         -   uses: actions/checkout@v2
 
-        -   name: Set up Python 3.8
+        -   name: Set up Python 3.9
             uses: actions/setup-python@v2
             with:
-                python-version: '3.8'
+                python-version: '3.9'
 
         -   uses: pre-commit/action@v2.0.0
 
@@ -24,7 +24,7 @@ jobs:
         timeout-minutes: 30
         strategy:
             matrix:
-                python-version: ['3.8', '3.9', '3.10', '3.11']
+                python-version: ['3.9', '3.10', '3.11']
 
         services:
             postgres:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     hooks:
     - id: mypy
       additional_dependencies:
-      - pydantic~=1.10.0
+      - pydantic~=2.0
       - types-python-dateutil
       - types-docutils
       exclude: >
@@ -41,10 +41,10 @@ repos:
     - id: pylint
       additional_dependencies:
       - aiida-core~=2.0
-      - fastapi~=0.65.1
+      - fastapi~=0.115.5
       - uvicorn[standard]~=0.19.0
-      - pydantic~=1.10.0
-      - graphene<3
+      - pydantic~=2.0
+      - graphene~=3.0
       - lark
       - python-dateutil~=2.0
       - python-jose

--- a/aiida_restapi/aiida_db_mappings.py
+++ b/aiida_restapi/aiida_db_mappings.py
@@ -31,7 +31,7 @@ class Comment(BaseModel):
     uuid: UUID = Field(description="Universally unique id")
     ctime: datetime = Field(description="Creation time")
     mtime: datetime = Field(description="Last modification time")
-    content: Optional[str] = Field(description="Content of the comment")
+    content: Optional[str] = Field(None, description="Content of the comment")
     user_id: int = Field(description="Created by user id (pk)")
     dbnode_id: int = Field(description="Associated node id (pk)")
 
@@ -43,7 +43,7 @@ class Computer(BaseModel):
     uuid: UUID = Field(description="Universally unique id")
     label: str = Field(description="Computer name")
     hostname: str = Field(description="Identifier for the computer within the network")
-    description: Optional[str] = Field(description="Description of the computer")
+    description: Optional[str] = Field(None, description="Description of the computer")
     scheduler_type: str = Field(
         description="Scheduler plugin type, to manage compute jobs"
     )
@@ -61,7 +61,7 @@ class Group(BaseModel):
     label: str = Field(description="Label of group")
     type_string: str = Field(description="type of the group")
     time: datetime = Field(description="Created time")
-    description: Optional[str] = Field(description="Description of group")
+    description: Optional[str] = Field(None, description="Description of group")
     extras: Json = Field(description="extra data about for the group")
     user_id: int = Field(description="Created by user id (pk)")
 
@@ -74,7 +74,7 @@ class Log(BaseModel):
     time: datetime = Field(description="Creation time")
     loggername: str = Field(description="The loggers name")
     levelname: str = Field(description="The log level")
-    message: Optional[str] = Field(description="The log message")
+    message: Optional[str] = Field(None, description="The log message")
     metadata: Json = Field(description="Metadata associated with the log")
     dbnode_id: int = Field(description="Associated node id (pk)")
 
@@ -91,7 +91,9 @@ class Node(BaseModel):
     ctime: datetime = Field(description="Creation time")
     mtime: datetime = Field(description="Last modification time")
     user_id: int = Field(description="Created by user id (pk)")
-    dbcomputer_id: Optional[int] = Field(description="Associated computer id (pk)")
+    dbcomputer_id: Optional[int] = Field(
+        None, description="Associated computer id (pk)"
+    )
     attributes: Json = Field(
         description="Attributes of the node (immutable after storing the node)",
     )
@@ -105,10 +107,10 @@ class User(BaseModel):
 
     id: int = Field(description="Unique id (pk)")
     email: str = Field(description="Email address of the user")
-    first_name: Optional[str] = Field(description="First name of the user")
-    last_name: Optional[str] = Field(description="Last name of the user")
+    first_name: Optional[str] = Field(None, description="First name of the user")
+    last_name: Optional[str] = Field(None, description="Last name of the user")
     institution: Optional[str] = Field(
-        description="Host institution or workplace of the user"
+        None, description="Host institution or workplace of the user"
     )
 
 
@@ -118,7 +120,7 @@ class Link(BaseModel):
     id: int = Field(description="Unique id (pk)")
     input_id: int = Field(description="Unique id (pk) of the input node")
     output_id: int = Field(description="Unique id (pk) of the output node")
-    label: Optional[str] = Field(description="The label of the link")
+    label: Optional[str] = Field(None, description="The label of the link")
     type: str = Field(description="The type of link")
 
 

--- a/aiida_restapi/config.py
+++ b/aiida_restapi/config.py
@@ -8,7 +8,7 @@ ACCESS_TOKEN_EXPIRE_MINUTES = 30
 
 fake_users_db = {
     "johndoe@example.com": {
-        "id": 23,
+        "pk": 23,
         "first_name": "John",
         "last_name": "Doe",
         "institution": "EPFL",

--- a/aiida_restapi/graphql/main.py
+++ b/aiida_restapi/graphql/main.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Main module that generates the full Graphql App."""
-from starlette.graphql import GraphQLApp
+from starlette_graphene3 import GraphQLApp
 
 from .basic import aiidaVersionPlugin, rowLimitMaxPlugin
 from .comments import CommentQueryPlugin, CommentsQueryPlugin

--- a/aiida_restapi/graphql/utils.py
+++ b/aiida_restapi/graphql/utils.py
@@ -16,44 +16,6 @@ class JSON(Scalar):
     String, Boolean, Int, Float, List or Object.
     """
 
-    @staticmethod
-    def serialize(value: Any) -> Any:
-        """Serialize the value to JSON format.
-
-        Args:
-            value: The value to serialize
-
-        Returns:
-            The serialized value
-        """
-        return value
-
-    @staticmethod
-    def parse_literal(node: ast.ValueNode) -> Any:
-        """Parse a literal value from a GraphQL AST node.
-
-        Args:
-            node: The AST node to parse
-
-        Returns:
-            The parsed value, or None if parsing fails
-        """
-        if isinstance(node, ast.StringValue):
-            return node.value
-        return None
-
-    @staticmethod
-    def parse_value(value: Any) -> Any:
-        """Parse a value from a GraphQL input.
-
-        Args:
-            value: The value to parse
-
-        Returns:
-            The parsed value
-        """
-        return value
-
 
 class FilterString(gr.String):
     """A string adhering to the AiiDA filter syntax."""

--- a/aiida_restapi/graphql/utils.py
+++ b/aiida_restapi/graphql/utils.py
@@ -3,39 +3,76 @@
 # pylint: disable=unused-argument,too-many-arguments
 
 
-from typing import Iterator
+from typing import Any, Iterator
 
 import graphene as gr
-from graphene.types.generic import GenericScalar
+from graphene.types.scalars import Scalar
 from graphql.language import ast
 
 
-class JSON(GenericScalar):
+class JSON(Scalar):
     """
-    Subclass of the  `GenericScalar` scalar type represents a generic
-    GraphQL scalar value that could be:
+    Custom scalar type for JSON values that could be:
     String, Boolean, Int, Float, List or Object.
     """
+
+    @staticmethod
+    def serialize(value: Any) -> Any:
+        """Serialize the value to JSON format.
+
+        Args:
+            value: The value to serialize
+
+        Returns:
+            The serialized value
+        """
+        return value
+
+    @staticmethod
+    def parse_literal(node: ast.ValueNode) -> Any:
+        """Parse a literal value from a GraphQL AST node.
+
+        Args:
+            node: The AST node to parse
+
+        Returns:
+            The parsed value, or None if parsing fails
+        """
+        if isinstance(node, ast.StringValue):
+            return node.value
+        return None
+
+    @staticmethod
+    def parse_value(value: Any) -> Any:
+        """Parse a value from a GraphQL input.
+
+        Args:
+            value: The value to parse
+
+        Returns:
+            The parsed value
+        """
+        return value
 
 
 class FilterString(gr.String):
     """A string adhering to the AiiDA filter syntax."""
 
 
-def selected_field_names_naive(selection_set: ast.SelectionSet) -> Iterator[str]:
+def selected_field_names_naive(selection_set: ast.SelectionSetNode) -> Iterator[str]:
     """Get the list of field names that are selected at the current level.
     Does not include nested names.
 
     Taken from: https://github.com/graphql-python/graphene/issues/57#issuecomment-774227086
     """
-    assert isinstance(selection_set, ast.SelectionSet)
+    assert isinstance(selection_set, ast.SelectionSetNode)
 
     for node in selection_set.selections:
         # Field
-        if isinstance(node, ast.Field):
+        if isinstance(node, ast.FieldNode):
             yield node.name.value
         # Fragment spread (`... fragmentName`)
-        elif isinstance(node, (ast.FragmentSpread, ast.InlineFragment)):
+        elif isinstance(node, (ast.FragmentSpreadNode, ast.InlineFragmentNode)):
             raise NotImplementedError(
                 "Fragments are not supported by this simplistic function"
             )

--- a/aiida_restapi/models.py
+++ b/aiida_restapi/models.py
@@ -295,7 +295,7 @@ class Group(AiidaModel):
             orm.QueryBuilder()
             .append(
                 cls._orm_entity,
-                filters={"pk": obj.id},
+                filters={"pk": orm_entity.id},
                 tag="fields",
                 project=["user_id", "time"],
             )

--- a/aiida_restapi/models.py
+++ b/aiida_restapi/models.py
@@ -286,7 +286,7 @@ class Group(AiidaModel):
         """Convert from ORM object.
 
         Args:
-            obj: The ORM object to convert
+            obj: The ORM entity to convert
 
         Returns:
             The converted Group object

--- a/aiida_restapi/models.py
+++ b/aiida_restapi/models.py
@@ -304,7 +304,7 @@ class Group(AiidaModel):
         orm_entity.user_id = query.dict()[0]["fields"]["user_id"]
         orm_entity.time = query.dict()[0]["fields"]["time"]
 
-        return super().from_orm(obj)
+        return super().from_orm(orm_entity)
 
 
 class Group_Post(AiidaModel):

--- a/aiida_restapi/models.py
+++ b/aiida_restapi/models.py
@@ -301,8 +301,8 @@ class Group(AiidaModel):
             )
             .limit(1)
         )
-        obj.user_id = query.dict()[0]["fields"]["user_id"]
-        obj.time = query.dict()[0]["fields"]["time"]
+        orm_entity.user_id = query.dict()[0]["fields"]["user_id"]
+        orm_entity.time = query.dict()[0]["fields"]["time"]
 
         return super().from_orm(obj)
 

--- a/aiida_restapi/models.py
+++ b/aiida_restapi/models.py
@@ -7,14 +7,14 @@ Models in this module mirror those in
 # pylint: disable=too-few-public-methods
 
 import inspect
-import io
 from datetime import datetime
-from typing import ClassVar, Dict, List, Optional, Type, TypeVar
+from pathlib import Path
+from typing import Any, ClassVar, Dict, List, Optional, Type, TypeVar
 from uuid import UUID
 
 from aiida import orm
 from fastapi import Form
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 # Template type for subclasses of `AiidaModel`
 ModelType = TypeVar("ModelType", bound="AiidaModel")
@@ -27,22 +27,27 @@ def as_form(cls: Type[BaseModel]) -> Type[BaseModel]:
 
     Note: Taken from https://github.com/tiangolo/fastapi/issues/2387
     """
-    new_params = [
-        inspect.Parameter(
-            field.alias,
-            inspect.Parameter.POSITIONAL_ONLY,
-            default=(Form(field.default) if not field.required else Form(...)),
-        )
-        for field in cls.__fields__.values()
-    ]
+    new_parameters = []
 
-    async def _as_form(**data: Dict) -> BaseModel:
+    for field_name, model_field in cls.model_fields.items():
+        new_parameters.append(
+            inspect.Parameter(
+                name=field_name,
+                kind=inspect.Parameter.POSITIONAL_ONLY,
+                default=Form(...)
+                if model_field.is_required()
+                else Form(model_field.default),
+                annotation=model_field.annotation,
+            )
+        )
+
+    async def as_form_func(**data: Dict[str, Any]) -> Any:
         return cls(**data)
 
-    sig = inspect.signature(_as_form)
-    sig = sig.replace(parameters=new_params)
-    _as_form.__signature__ = sig  # type: ignore
-    setattr(cls, "as_form", _as_form)
+    sig = inspect.signature(as_form_func)
+    sig = sig.replace(parameters=new_parameters)
+    as_form_func.__signature__ = sig  # type: ignore
+    setattr(cls, "as_form", as_form_func)
     return cls
 
 
@@ -50,12 +55,7 @@ class AiidaModel(BaseModel):
     """A mapping of an AiiDA entity to a pydantic model."""
 
     _orm_entity: ClassVar[Type[orm.entities.Entity]] = orm.entities.Entity
-
-    class Config:
-        """The models configuration."""
-
-        orm_mode = True
-        extra = "forbid"
+    model_config = ConfigDict(from_attributes=True, extra="forbid")
 
     @classmethod
     def get_projectable_properties(cls) -> List[str]:
@@ -102,31 +102,27 @@ class Comment(AiidaModel):
 
     _orm_entity = orm.Comment
 
-    id: Optional[int] = Field(description="Unique comment id (pk)")
+    id: Optional[int] = Field(None, description="Unique comment id (pk)")
     uuid: str = Field(description="Unique comment uuid")
-    ctime: Optional[datetime] = Field(description="Creation time")
-    mtime: Optional[datetime] = Field(description="Last modification time")
-    content: Optional[str] = Field(description="Comment content")
-    dbnode_id: Optional[int] = Field(description="Unique node id (pk)")
-    user_id: Optional[int] = Field(description="Unique user id (pk)")
+    ctime: Optional[datetime] = Field(None, description="Creation time")
+    mtime: Optional[datetime] = Field(None, description="Last modification time")
+    content: Optional[str] = Field(None, description="Comment content")
+    dbnode_id: Optional[int] = Field(None, description="Unique node id (pk)")
+    user_id: Optional[int] = Field(None, description="Unique user id (pk)")
 
 
 class User(AiidaModel):
     """AiiDA User model."""
 
     _orm_entity = orm.User
+    model_config = ConfigDict(extra="allow")
 
-    class Config:
-        """The models configuration."""
-
-        extra = "allow"
-
-    id: Optional[int] = Field(description="Unique user id (pk)")
+    id: Optional[int] = Field(None, description="Unique user id (pk)")
     email: str = Field(description="Email address of the user")
-    first_name: Optional[str] = Field(description="First name of the user")
-    last_name: Optional[str] = Field(description="Last name of the user")
+    first_name: Optional[str] = Field(None, description="First name of the user")
+    last_name: Optional[str] = Field(None, description="Last name of the user")
     institution: Optional[str] = Field(
-        description="Host institution or workplace of the user"
+        None, description="Host institution or workplace of the user"
     )
 
 
@@ -135,24 +131,27 @@ class Computer(AiidaModel):
 
     _orm_entity = orm.Computer
 
-    id: Optional[int] = Field(description="Unique computer id (pk)")
-    uuid: Optional[str] = Field(description="Unique id for computer")
+    id: Optional[int] = Field(None, description="Unique computer id (pk)")
+    uuid: Optional[str] = Field(None, description="Unique id for computer")
     label: str = Field(description="Used to identify a computer. Must be unique")
     hostname: Optional[str] = Field(
-        description="Label that identifies the computer within the network"
+        None, description="Label that identifies the computer within the network"
     )
     scheduler_type: Optional[str] = Field(
-        description="The scheduler (and plugin) that the computer uses to manage jobs"
+        None,
+        description="The scheduler (and plugin) that the computer uses to manage jobs",
     )
     transport_type: Optional[str] = Field(
+        None,
         description="The transport (and plugin) \
-                    required to copy files and communicate to and from the computer"
+                    required to copy files and communicate to and from the computer",
     )
     metadata: Optional[dict] = Field(
-        description="General settings for these communication and management protocols"
+        None,
+        description="General settings for these communication and management protocols",
     )
 
-    description: Optional[str] = Field(description="Description of node")
+    description: Optional[str] = Field(None, description="Description of node")
 
 
 class Node(AiidaModel):
@@ -160,23 +159,28 @@ class Node(AiidaModel):
 
     _orm_entity = orm.Node
 
-    id: Optional[int] = Field(description="Unique id (pk)")
-    uuid: Optional[UUID] = Field(description="Unique uuid")
-    node_type: Optional[str] = Field(description="Node type")
-    process_type: Optional[str] = Field(description="Process type")
+    id: Optional[int] = Field(None, description="Unique id (pk)")
+    uuid: Optional[UUID] = Field(None, description="Unique uuid")
+    node_type: Optional[str] = Field(None, description="Node type")
+    process_type: Optional[str] = Field(None, description="Process type")
     label: str = Field(description="Label of node")
-    description: Optional[str] = Field(description="Description of node")
-    ctime: Optional[datetime] = Field(description="Creation time")
-    mtime: Optional[datetime] = Field(description="Last modification time")
-    user_id: Optional[int] = Field(description="Created by user id (pk)")
-    dbcomputer_id: Optional[int] = Field(description="Associated computer id (pk)")
+    description: Optional[str] = Field(None, description="Description of node")
+    ctime: Optional[datetime] = Field(None, description="Creation time")
+    mtime: Optional[datetime] = Field(None, description="Last modification time")
+    user_id: Optional[int] = Field(None, description="Created by user id (pk)")
+    dbcomputer_id: Optional[int] = Field(
+        None, description="Associated computer id (pk)"
+    )
     attributes: Optional[Dict] = Field(
+        None,
         description="Variable attributes of the node",
     )
     extras: Optional[Dict] = Field(
+        None,
         description="Variable extras (unsealed) of the node",
     )
     repository_metadata: Optional[Dict] = Field(
+        None,
         description="Metadata about file repository associated with this node",
     )
 
@@ -186,15 +190,19 @@ class Node_Post(AiidaModel):
     """AiiDA model for posting Nodes."""
 
     entry_point: str = Field(description="Entry_point")
-    process_type: Optional[str] = Field(description="Process type")
-    label: Optional[str] = Field(description="Label of node")
-    description: Optional[str] = Field(description="Description of node")
-    user_id: Optional[int] = Field(description="Created by user id (pk)")
-    dbcomputer_id: Optional[int] = Field(description="Associated computer id (pk)")
+    process_type: Optional[str] = Field(None, description="Process type")
+    label: Optional[str] = Field(None, description="Label of node")
+    description: Optional[str] = Field(None, description="Description of node")
+    user_id: Optional[int] = Field(None, description="Created by user id (pk)")
+    dbcomputer_id: Optional[int] = Field(
+        None, description="Associated computer id (pk)"
+    )
     attributes: Optional[Dict] = Field(
+        None,
         description="Variable attributes of the node",
     )
     extras: Optional[Dict] = Field(
+        None,
         description="Variable extras (unsealed) of the node",
     )
 
@@ -246,13 +254,13 @@ class Node_Post(AiidaModel):
         cls: Type[ModelType],
         orm_class: orm.Node,
         node_dict: dict,
-        file: bytes,
+        file: Path,
     ) -> orm.Node:
         """Create and Store new Node with file"""
         attributes = node_dict.pop("attributes", {})
         extras = node_dict.pop("extras", {})
 
-        orm_object = orm_class(file=io.BytesIO(file), **node_dict, **attributes)
+        orm_object = orm_class(file=file, **node_dict, **attributes)
 
         orm_object.base.extras.set_many(extras)
         orm_object.store()
@@ -268,27 +276,35 @@ class Group(AiidaModel):
     uuid: UUID = Field(description="Universally unique id")
     label: str = Field(description="Label of group")
     type_string: str = Field(description="type of the group")
-    description: Optional[str] = Field(description="Description of group")
-    extras: Optional[Dict] = Field(description="extra data about for the group")
+    description: Optional[str] = Field(None, description="Description of group")
+    extras: Optional[Dict] = Field(None, description="extra data about for the group")
     time: datetime = Field(description="Created time")
     user_id: int = Field(description="Created by user id (pk)")
 
     @classmethod
-    def from_orm(cls, orm_entity: orm.Group) -> orm.Group:
+    def from_orm(cls, obj: orm.Group) -> orm.Group:
+        """Convert from ORM object.
+
+        Args:
+            obj: The ORM object to convert
+
+        Returns:
+            The converted Group object
+        """
         query = (
             orm.QueryBuilder()
             .append(
                 cls._orm_entity,
-                filters={"id": orm_entity.id},
+                filters={"pk": obj.id},
                 tag="fields",
                 project=["user_id", "time"],
             )
             .limit(1)
         )
-        orm_entity.user_id = query.dict()[0]["fields"]["user_id"]
-        orm_entity.time = query.dict()[0]["fields"]["time"]
+        obj.user_id = query.dict()[0]["fields"]["user_id"]
+        obj.time = query.dict()[0]["fields"]["time"]
 
-        return super().from_orm(orm_entity)
+        return super().from_orm(obj)
 
 
 class Group_Post(AiidaModel):
@@ -297,8 +313,10 @@ class Group_Post(AiidaModel):
     _orm_entity = orm.Group
 
     label: str = Field(description="Used to access the group. Must be unique.")
-    type_string: Optional[str] = Field(description="Type of the group")
-    description: Optional[str] = Field(description="Short description of the group.")
+    type_string: Optional[str] = Field(None, description="Type of the group")
+    description: Optional[str] = Field(
+        None, description="Short description of the group."
+    )
 
 
 class Process(AiidaModel):
@@ -306,23 +324,28 @@ class Process(AiidaModel):
 
     _orm_entity = orm.ProcessNode
 
-    id: Optional[int] = Field(description="Unique id (pk)")
-    uuid: Optional[UUID] = Field(description="Universally unique identifier")
-    node_type: Optional[str] = Field(description="Node type")
-    process_type: Optional[str] = Field(description="Process type")
+    id: Optional[int] = Field(None, description="Unique id (pk)")
+    uuid: Optional[UUID] = Field(None, description="Universally unique identifier")
+    node_type: Optional[str] = Field(None, description="Node type")
+    process_type: Optional[str] = Field(None, description="Process type")
     label: str = Field(description="Label of node")
-    description: Optional[str] = Field(description="Description of node")
-    ctime: Optional[datetime] = Field(description="Creation time")
-    mtime: Optional[datetime] = Field(description="Last modification time")
-    user_id: Optional[int] = Field(description="Created by user id (pk)")
-    dbcomputer_id: Optional[int] = Field(description="Associated computer id (pk)")
+    description: Optional[str] = Field(None, description="Description of node")
+    ctime: Optional[datetime] = Field(None, description="Creation time")
+    mtime: Optional[datetime] = Field(None, description="Last modification time")
+    user_id: Optional[int] = Field(None, description="Created by user id (pk)")
+    dbcomputer_id: Optional[int] = Field(
+        None, description="Associated computer id (pk)"
+    )
     attributes: Optional[Dict] = Field(
+        None,
         description="Variable attributes of the node",
     )
     extras: Optional[Dict] = Field(
+        None,
         description="Variable extras (unsealed) of the node",
     )
     repository_metadata: Optional[Dict] = Field(
+        None,
         description="Metadata about file repository associated with this node",
     )
 

--- a/aiida_restapi/models.py
+++ b/aiida_restapi/models.py
@@ -282,7 +282,7 @@ class Group(AiidaModel):
     user_id: int = Field(description="Created by user id (pk)")
 
     @classmethod
-    def from_orm(cls, obj: orm.Group) -> orm.Group:
+    def from_orm(cls, orm_entity: orm.Group) -> orm.Group:
         """Convert from ORM object.
 
         Args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ testing = [
     'pytest-regressions',
     'pytest-cov',
     'requests',
+    'httpx',
 ]
 
 [tool.flit.module]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,11 @@ keywords = ['aiida', 'workflows']
 requires-python = '>=3.8'
 dependencies = [
     'aiida-core~=2.0',
-    'fastapi~=0.65.1',
+    'fastapi~=0.115.5',
     'uvicorn[standard]~=0.19.0',
-    'pydantic~=1.10',
-    'graphene~=2.0',
+    'pydantic~=2.0',
+    'starlette-graphene3~=0.6.0',
+    'graphene~=3.0',
     'python-dateutil~=2.0',
     'lark~=0.11.0',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,14 +16,13 @@ classifiers = [
     'Intended Audience :: Science/Research',
     'License :: OSI Approved :: MIT License',
     'Programming Language :: Python',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Topic :: Scientific/Engineering'
 ]
 keywords = ['aiida', 'workflows']
-requires-python = '>=3.8'
+requires-python = '>=3.9'
 dependencies = [
     'aiida-core~=2.0',
     'fastapi~=0.115.5',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from aiida.common.exceptions import NotExistent
 from aiida.engine import ProcessState
 from aiida.orm import WorkChainNode, WorkFunctionNode
 from fastapi.testclient import TestClient
+from httpx import AsyncClient
 
 from aiida_restapi import app, config
 from aiida_restapi.routers.auth import UserInDB, get_current_user
@@ -28,6 +29,23 @@ def clear_database_auto(aiida_profile_clean):  # pylint: disable=unused-argument
 def client():
     """Return fastapi test client."""
     yield TestClient(app)
+
+
+@pytest.fixture
+def anyio_backend():
+    """Return the async IO backend to use for testing.
+
+    Returns:
+        str: The name of the backend to use
+    """
+    return "asyncio"
+
+
+@pytest.fixture(scope="function")
+async def async_client():
+    """Return fastapi async test client."""
+    async with AsyncClient(app=app, base_url="http://test") as async_test_client:
+        yield async_test_client
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -3,6 +3,9 @@
 
 
 import io
+import json
+
+import pytest
 
 
 def test_get_nodes_projectable(client):
@@ -55,13 +58,14 @@ def test_create_dict(client, authenticate):  # pylint: disable=unused-argument
     assert response.status_code == 200, response.content
 
 
-def test_create_code(
-    default_computers, client, authenticate
+@pytest.mark.anyio
+async def test_create_code(
+    default_computers, async_client, authenticate
 ):  # pylint: disable=unused-argument
     """Test creating a new Code."""
 
     for comp_id in default_computers:
-        response = client.post(
+        response = await async_client.post(
             "/nodes",
             json={
                 "entry_point": "core.code.installed",
@@ -200,16 +204,20 @@ def test_create_single_file_upload(
             "multipart/form-data",
         )
     }
-    params = {
-        "entry_point": "core.singlefile",
-        "process_type": None,
-        "description": "Testing single upload file",
-        "attributes": {},
+    data = {
+        "params": json.dumps(
+            {
+                "entry_point": "core.singlefile",
+                "process_type": None,
+                "description": "Testing single upload file",
+                "attributes": {},
+            }
+        )
     }
 
-    response = client.post("/nodes/singlefile", files=test_file, data=params)
+    response = client.post("/nodes/singlefile", files=test_file, data=data)
 
-    assert response.status_code == 200
+    assert response.status_code == 200, response.json()
 
 
 def test_create_node_wrong_value(

--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -2,6 +2,7 @@
 """Test the /processes endpoint"""
 import io
 
+import pytest
 from aiida.orm import Dict, SinglefileData
 
 
@@ -44,12 +45,13 @@ def test_get_single_processes(
         assert response.status_code == 200
 
 
-def test_add_process(
-    default_test_add_process, client, authenticate
+@pytest.mark.anyio
+async def test_add_process(
+    default_test_add_process, async_client, authenticate
 ):  # pylint: disable=unused-argument
     """Test adding new process"""
     code_id, x_id, y_id = default_test_add_process
-    response = client.post(
+    response = await async_client.post(
         "/processes",
         json={
             "label": "test_new_process",
@@ -116,8 +118,9 @@ def test_add_process_invalid_node_id(
     }
 
 
-def test_add_process_nested_inputs(
-    default_test_add_process, client, authenticate
+@pytest.mark.anyio
+async def test_add_process_nested_inputs(
+    default_test_add_process, async_client, authenticate
 ):  # pylint: disable=unused-argument
     """Test adding new process that has nested inputs"""
     code_id, _, _ = default_test_add_process
@@ -128,7 +131,7 @@ def test_add_process_nested_inputs(
     ).store()
     single_file = SinglefileData(io.StringIO("content")).store()
 
-    response = client.post(
+    response = await async_client.post(
         "/processes",
         json={
             "label": "test_new_process",

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """Test the /users endpoint"""
 
+import pytest
+
 
 def test_get_single_user(default_users, client):  # pylint: disable=unused-argument
     """Test retrieving a single user."""
@@ -20,14 +22,17 @@ def test_get_users(default_users, client):  # pylint: disable=unused-argument
     assert len(response.json()) == 2 + 1
 
 
-def test_create_user(client, authenticate):  # pylint: disable=unused-argument
+@pytest.mark.anyio
+async def test_create_user(
+    async_client, authenticate
+):  # pylint: disable=unused-argument
     """Test creating a new user."""
-    response = client.post(
+    response = await async_client.post(
         "/users", json={"first_name": "New", "email": "aiida@localhost"}
     )
     assert response.status_code == 200, response.content
 
-    response = client.get("/users")
+    response = await async_client.get("/users")
     first_names = [user["first_name"] for user in response.json()]
     assert "New" in first_names
 


### PR DESCRIPTION
In order to make this project work with AiiDA 2.5+, this pr migrates to 

* pydantic 2
* fastapi 0.115.5 (previous version was not comptaibly with pydantic 2)
* starlette.graphql (which was removed from starlette/fastapi) was replaced with starlette-graphene3
* and as a result, graphene 2 also needed to be migrated to graphene 3

In the process of these migrations, the following things were changed:

* tests that start aiida processes needed to be set as async and use an async test client, otherwise there was an event-loop conflict with aiida;
* the upload file endpoint was not working with the previous approach, and now uses Fastapi's upload file that can handle large files in a manner that doesn't need to load it fully into memory.

Fixes #70