### PR TITLE
Add `/server/*` endpoint group to REST API

### DIFF
--- a/aiida_restapi/config.py
+++ b/aiida_restapi/config.py
@@ -1,5 +1,7 @@
 """Configuration of API"""
 
+from importlib.metadata import version
+
 # to get a string like this run:
 # openssl rand -hex 32
 SECRET_KEY = '09d25e094faa6ca2556c818166b7a9563b93f7099f6f0f4caa6cf63b88e8d3e7'
@@ -17,4 +19,12 @@ fake_users_db = {
         'hashed_password': PASSWORD_HASH,
         'disabled': False,
     }
+}
+
+# The chunks size for streaming data for download
+DOWNLOAD_CHUNK_SIZE = 1024
+
+API_CONFIG = {
+    'PREFIX': version('aiida_restapi'),  # prefix for all URLs
+    'VERSION': '0.1.0a',
 }

--- a/aiida_restapi/config.py
+++ b/aiida_restapi/config.py
@@ -1,6 +1,6 @@
 """Configuration of API"""
 
-from importlib.metadata import version
+from aiida_restapi import __version__
 
 # to get a string like this run:
 # openssl rand -hex 32
@@ -25,6 +25,6 @@ fake_users_db = {
 DOWNLOAD_CHUNK_SIZE = 1024
 
 API_CONFIG = {
-    'PREFIX': version('aiida_restapi'),  # prefix for all URLs
-    'VERSION': '0.1.0a',
+    'PREFIX': '/api/v0',  # prefix for all URLs
+    'VERSION': __version__,
 }

--- a/aiida_restapi/config.py
+++ b/aiida_restapi/config.py
@@ -21,9 +21,6 @@ fake_users_db = {
     }
 }
 
-# The chunks size for streaming data for download
-DOWNLOAD_CHUNK_SIZE = 1024
-
 API_CONFIG = {
     'PREFIX': '/api/v0',  # prefix for all URLs
     'VERSION': __version__,

--- a/aiida_restapi/main.py
+++ b/aiida_restapi/main.py
@@ -1,9 +1,12 @@
 """Declaration of FastAPI application."""
 
+from typing import Any
+
 from fastapi import FastAPI
 
+from aiida_restapi.config import API_CONFIG
 from aiida_restapi.graphql import main
-from aiida_restapi.routers import auth, computers, daemon, groups, nodes, process, users
+from aiida_restapi.routers import auth, computers, daemon, groups, nodes, process, server, users
 
 app = FastAPI()
 app.include_router(auth.router)
@@ -14,3 +17,31 @@ app.include_router(groups.router)
 app.include_router(users.router)
 app.include_router(process.router)
 app.add_route('/graphql', main.app, name='graphql')
+
+
+# We need to create this endpoint here instead of in the server to avoid circular imports, since it is dependent on the
+# app
+@server.router.get('/server/endpoints', response_model=dict[str, Any])
+async def get_server_endpoints() -> dict[str, Any]:
+    """List available routes"""
+    import re
+
+    from fastapi.routing import APIRoute
+
+    routes = []
+    for route in app.routes:
+        if isinstance(route, APIRoute):
+            full_path = API_CONFIG['PREFIX'] + route.path
+            match = re.search(r'^\/([^\/]+)', route.path)
+            endpoint_group = None if match is None else match.group(1)
+            routes.append(
+                {
+                    'path': full_path,
+                    'group': endpoint_group,
+                    'methods': route.methods,
+                }
+            )
+    return {'endpoints': routes}
+
+
+app.include_router(server.router)

--- a/aiida_restapi/main.py
+++ b/aiida_restapi/main.py
@@ -1,10 +1,7 @@
 """Declaration of FastAPI application."""
 
-from typing import Any
-
 from fastapi import FastAPI
 
-from aiida_restapi.config import API_CONFIG
 from aiida_restapi.graphql import main
 from aiida_restapi.routers import auth, computers, daemon, groups, nodes, process, server, users
 
@@ -16,32 +13,5 @@ app.include_router(nodes.router)
 app.include_router(groups.router)
 app.include_router(users.router)
 app.include_router(process.router)
-app.add_route('/graphql', main.app, name='graphql')
-
-
-# We need to create this endpoint here instead of in the server to avoid circular imports, since it is dependent on the
-# app
-@server.router.get('/server/endpoints', response_model=dict[str, Any])
-async def get_server_endpoints() -> dict[str, Any]:
-    """List available routes"""
-    import re
-
-    from fastapi.routing import APIRoute
-
-    routes = []
-    for route in app.routes:
-        if isinstance(route, APIRoute):
-            full_path = API_CONFIG['PREFIX'] + route.path
-            match = re.search(r'^\/([^\/]+)', route.path)
-            endpoint_group = None if match is None else match.group(1)
-            routes.append(
-                {
-                    'path': full_path,
-                    'group': endpoint_group,
-                    'methods': route.methods,
-                }
-            )
-    return {'endpoints': routes}
-
-
 app.include_router(server.router)
+app.add_route('/graphql', main.app, name='graphql')

--- a/aiida_restapi/routers/server.py
+++ b/aiida_restapi/routers/server.py
@@ -1,0 +1,26 @@
+"""Declaration of FastAPI application."""
+
+from typing import Any
+
+from aiida import __version__ as aiida_version
+from fastapi import APIRouter
+
+from aiida_restapi.config import API_CONFIG
+
+router = APIRouter()
+
+
+@router.get('/server/info', response_model=dict[str, Any])
+async def get_server_info() -> dict[str, Any]:
+    """Get the API version information"""
+    response = {}
+    api_version = API_CONFIG['VERSION'].split('.')
+    response['API_major_version'] = api_version[0]
+    response['API_minor_version'] = api_version[1]
+    response['API_revision_version'] = api_version[2]
+    # Add Rest API prefix
+    response['API_prefix'] = API_CONFIG['PREFIX']
+
+    # Add AiiDA version
+    response['AiiDA_version'] = aiida_version
+    return response

--- a/aiida_restapi/routers/server.py
+++ b/aiida_restapi/routers/server.py
@@ -1,26 +1,32 @@
 """Declaration of FastAPI application."""
 
-from typing import Any
-
 from aiida import __version__ as aiida_version
 from fastapi import APIRouter
+from pydantic import BaseModel
 
 from aiida_restapi.config import API_CONFIG
 
 router = APIRouter()
 
 
-@router.get('/server/info', response_model=dict[str, Any])
-async def get_server_info() -> dict[str, Any]:
-    """Get the API version information"""
-    response = {}
-    api_version = API_CONFIG['VERSION'].split('.')
-    response['API_major_version'] = api_version[0]
-    response['API_minor_version'] = api_version[1]
-    response['API_revision_version'] = api_version[2]
-    # Add Rest API prefix
-    response['API_prefix'] = API_CONFIG['PREFIX']
+class ServerInfo(BaseModel):
+    """API version information."""
 
-    # Add AiiDA version
-    response['AiiDA_version'] = aiida_version
-    return response
+    API_major_version: str
+    API_minor_version: str
+    API_revision_version: str
+    API_prefix: str
+    AiiDA_version: str
+
+
+@router.get('/server/info', response_model=ServerInfo)
+async def get_server_info() -> ServerInfo:
+    """Get the API version information"""
+    api_version = API_CONFIG['VERSION'].split('.')
+    return ServerInfo(
+        API_major_version=api_version[0],
+        API_minor_version=api_version[1],
+        API_revision_version=api_version[2],
+        API_prefix=API_CONFIG['PREFIX'],
+        AiiDA_version=aiida_version,
+    )

--- a/aiida_restapi/routers/server.py
+++ b/aiida_restapi/routers/server.py
@@ -4,24 +4,24 @@ from __future__ import annotations
 
 import re
 
+import pydantic as pdt
 from aiida import __version__ as aiida_version
 from fastapi import APIRouter, Request
 from fastapi.routing import APIRoute
-from pydantic import BaseModel
 
 from aiida_restapi.config import API_CONFIG
 
 router = APIRouter()
 
 
-class ServerInfo(BaseModel):
+class ServerInfo(pdt.BaseModel):
     """API version information."""
 
-    API_major_version: str
-    API_minor_version: str
-    API_revision_version: str
-    API_prefix: str
-    AiiDA_version: str
+    API_major_version: str = pdt.Field(description='Major version of the API')
+    API_minor_version: str = pdt.Field(description='Minor version of the API')
+    API_revision_version: str = pdt.Field(description='Revision version of the API')
+    API_prefix: str = pdt.Field(description='Prefix for all API endpoints')
+    AiiDA_version: str = pdt.Field(description='Version of the AiiDA installation')
 
 
 @router.get('/server/info', response_model=ServerInfo)
@@ -37,12 +37,12 @@ async def get_server_info() -> ServerInfo:
     )
 
 
-class ServerEndpoint(BaseModel):
+class ServerEndpoint(pdt.BaseModel):
     """API endpoint."""
 
-    path: str
-    group: str | None
-    methods: set[str]
+    path: str = pdt.Field(description='Path of the endpoint')
+    group: str | None = pdt.Field(description='Group of the endpoint')
+    methods: set[str] = pdt.Field(description='HTTP methods supported by the endpoint')
 
 
 @router.get('/server/endpoints', response_model=dict[str, list[ServerEndpoint]])

--- a/aiida_restapi/routers/server.py
+++ b/aiida_restapi/routers/server.py
@@ -1,7 +1,10 @@
 """Declaration of FastAPI application."""
 
+import re
+
 from aiida import __version__ as aiida_version
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
+from fastapi.routing import APIRoute
 from pydantic import BaseModel
 
 from aiida_restapi.config import API_CONFIG
@@ -21,7 +24,7 @@ class ServerInfo(BaseModel):
 
 @router.get('/server/info', response_model=ServerInfo)
 async def get_server_info() -> ServerInfo:
-    """Get the API version information"""
+    """Get the API version information."""
     api_version = API_CONFIG['VERSION'].split('.')
     return ServerInfo(
         API_major_version=api_version[0],
@@ -30,3 +33,31 @@ async def get_server_info() -> ServerInfo:
         API_prefix=API_CONFIG['PREFIX'],
         AiiDA_version=aiida_version,
     )
+
+
+class ServerEndpoint(BaseModel):
+    """API endpoint."""
+
+    path: str
+    group: str | None
+    methods: set[str]
+
+
+@router.get('/server/endpoints', response_model=dict[str, list[ServerEndpoint]])
+async def get_server_endpoints(request: Request) -> dict[str, list[ServerEndpoint]]:
+    """List available routes."""
+
+    routes: list[ServerEndpoint] = []
+    for route in request.app.routes:
+        if isinstance(route, APIRoute):
+            full_path = API_CONFIG['PREFIX'] + route.path
+            match = re.search(r'^\/([^\/]+)', route.path)
+            endpoint_group = None if match is None else match.group(1)
+            endpoint = ServerEndpoint(
+                path=full_path,
+                group=endpoint_group,
+                methods=route.methods,
+            )
+            routes.append(endpoint)
+
+    return {'endpoints': routes}

--- a/aiida_restapi/routers/server.py
+++ b/aiida_restapi/routers/server.py
@@ -1,5 +1,7 @@
 """Declaration of FastAPI application."""
 
+from __future__ import annotations
+
 import re
 
 from aiida import __version__ as aiida_version

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -320,32 +320,39 @@ def create_computer():
     return _func
 
 
+def _create_node(
+    *,
+    label: str = '',
+    description: str = '',
+    attributes: Optional[dict] = None,
+    extras: Optional[dict] = None,
+    process_type: Optional[str] = None,
+    computer: Optional[orm.Computer] = None,
+    store: bool = True,
+) -> orm.nodes.Node:
+    node = orm.CalcJobNode(computer=computer) if process_type else orm.Data(computer=computer)
+    node.label = label
+    node.description = description
+    node.base.attributes.reset(attributes or {})
+    node.base.extras.reset(extras or {})
+    if process_type is not None:
+        node.process_type = process_type
+    if store:
+        node.store()
+    return node
+
+
 @pytest.fixture
 def create_node():
     """Create and store an AiiDA Node."""
+    return _create_node
 
-    def _func(
-        *,
-        label: str = '',
-        description: str = '',
-        attributes: Optional[dict] = None,
-        extras: Optional[dict] = None,
-        process_type: Optional[str] = None,
-        computer: Optional[orm.Computer] = None,
-        store: bool = True,
-    ) -> orm.nodes.Node:
-        node = orm.CalcJobNode(computer=computer) if process_type else orm.Data(computer=computer)
-        node.label = label
-        node.description = description
-        node.base.attributes.reset(attributes or {})
-        node.base.extras.reset(extras or {})
-        if process_type is not None:
-            node.process_type = process_type
-        if store:
-            node.store()
-        return node
 
-    return _func
+@pytest.fixture
+def calcjob_nodes():
+    """Populate database with calcjob nodes."""
+    nodes = [_create_node(label=f'node {i}', process_type='', store=False) for i in range(4)]
+    return nodes
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -320,39 +320,32 @@ def create_computer():
     return _func
 
 
-def _create_node(
-    *,
-    label: str = '',
-    description: str = '',
-    attributes: Optional[dict] = None,
-    extras: Optional[dict] = None,
-    process_type: Optional[str] = None,
-    computer: Optional[orm.Computer] = None,
-    store: bool = True,
-) -> orm.nodes.Node:
-    node = orm.CalcJobNode(computer=computer) if process_type else orm.Data(computer=computer)
-    node.label = label
-    node.description = description
-    node.base.attributes.reset(attributes or {})
-    node.base.extras.reset(extras or {})
-    if process_type is not None:
-        node.process_type = process_type
-    if store:
-        node.store()
-    return node
-
-
 @pytest.fixture
 def create_node():
     """Create and store an AiiDA Node."""
-    return _create_node
 
+    def _func(
+        *,
+        label: str = '',
+        description: str = '',
+        attributes: Optional[dict] = None,
+        extras: Optional[dict] = None,
+        process_type: Optional[str] = None,
+        computer: Optional[orm.Computer] = None,
+        store: bool = True,
+    ) -> orm.nodes.Node:
+        node = orm.CalcJobNode(computer=computer) if process_type else orm.Data(computer=computer)
+        node.label = label
+        node.description = description
+        node.base.attributes.reset(attributes or {})
+        node.base.extras.reset(extras or {})
+        if process_type is not None:
+            node.process_type = process_type
+        if store:
+            node.store()
+        return node
 
-@pytest.fixture
-def calcjob_nodes():
-    """Populate database with calcjob nodes."""
-    nodes = [_create_node(label=f'node {i}', process_type='', store=False) for i in range(4)]
-    return nodes
+    return _func
 
 
 @pytest.fixture


### PR DESCRIPTION
This includes the implementation of the endpoints `/server/info` and `/server/endpoints`. There are some slight changes over the old REST API:

* The endpoint `/server/` has been moved to `/server/info`
* The key name in the response of endpoint `/server/endpoints` has been changed from `available_endpoints` to `endpoints`
* The strings in the response of endpoint `/server/endpoints` has been splitted up into a dictionary with keys "methods", "group", "path" that contain the same information as the strings but structured