### PR TITLE
Remove redundant streaming in download of file

### DIFF
--- a/aiida_restapi/config.py
+++ b/aiida_restapi/config.py
@@ -17,6 +17,3 @@ fake_users_db = {
         'disabled': False,
     }
 }
-
-# The chunks size for streaming data for download
-DOWNLOAD_CHUNK_SIZE = 1024

--- a/aiida_restapi/routers/nodes.py
+++ b/aiida_restapi/routers/nodes.py
@@ -15,7 +15,6 @@ from fastapi.responses import StreamingResponse
 from pydantic import ValidationError
 
 from aiida_restapi import models, resources
-from aiida_restapi.config import DOWNLOAD_CHUNK_SIZE
 
 from .auth import get_current_active_user
 
@@ -73,8 +72,7 @@ async def download_node(nodes_id: int, download_format: Optional[str] = None) ->
 
         def stream() -> Generator[bytes, None, None]:
             with io.BytesIO(exported_bytes) as handler:
-                while chunk := handler.read(DOWNLOAD_CHUNK_SIZE):
-                    yield chunk
+                yield from handler
 
         return StreamingResponse(stream(), media_type=f'application/{download_format}')
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -167,13 +167,9 @@ def default_nodes():
 
 @pytest.fixture(scope='function')
 def array_data_node():
-    """Populate database with downloadable node (implmenting a _prepare_* function).
-    For testing the chunking of the streaming we create an array that needs to be splitted int two chunks."""
+    """Populate database with downloadable node (implmenting a _prepare_* function)."""
 
-    from aiida_restapi.config import DOWNLOAD_CHUNK_SIZE
-
-    nb_elements = DOWNLOAD_CHUNK_SIZE // 64 + 1
-    return orm.ArrayData(np.arange(nb_elements, dtype=np.int64)).store()
+    return orm.ArrayData(np.arange(4)).store()
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
In PR #71 a streaming mechanism has been implemented for the endpoint `/nodes/{nodes_id}/download`, this however is already taken care by FastAPI StreamingResponse and is therefore redundant and can be removed.