### PR TITLE
Add `/nodes/statistics/user` endpoint to REST API

### DIFF
--- a/aiida_restapi/routers/nodes.py
+++ b/aiida_restapi/routers/nodes.py
@@ -87,8 +87,9 @@ async def get_node_projectable_properties(
 
 
 @read_router.get('/nodes/statistics', response_model=dict[str, t.Any])
+@with_dbenv()
 async def get_nodes_statistics(user: int | None = None) -> dict[str, t.Any]:
-    """Get statistics for nodes endpoint"""
+    """Get node statistics."""
 
     from aiida.manage import get_manager
 

--- a/aiida_restapi/routers/nodes.py
+++ b/aiida_restapi/routers/nodes.py
@@ -86,7 +86,34 @@ async def get_node_projectable_properties(
         raise HTTPException(status_code=422, detail=str(err)) from err
 
 
-@read_router.get('/nodes/statistics', response_model=dict[str, t.Any])
+class NodeStatistics(pdt.BaseModel):
+    """Pydantic model representing node statistics."""
+
+    total: int = pdt.Field(
+        description='Total number of nodes.',
+        examples=[47],
+    )
+    types: dict[str, int] = pdt.Field(
+        description='Number of nodes by type.',
+        examples=[
+            {
+                'data.core.int.Int.': 42,
+                'data.core.singlefile.SinglefileData.': 5,
+            }
+        ],
+    )
+    ctime_by_day: dict[str, int] = pdt.Field(
+        description='Number of nodes created per day (YYYY-MM-DD).',
+        examples=[
+            {
+                '2012-01-01': 10,
+                '2012-01-02': 15,
+            }
+        ],
+    )
+
+
+@read_router.get('/nodes/statistics', response_model=NodeStatistics)
 @with_dbenv()
 async def get_nodes_statistics(user: int | None = None) -> dict[str, t.Any]:
     """Get node statistics."""

--- a/aiida_restapi/routers/nodes.py
+++ b/aiida_restapi/routers/nodes.py
@@ -86,6 +86,16 @@ async def get_node_projectable_properties(
         raise HTTPException(status_code=422, detail=str(err)) from err
 
 
+@read_router.get('/nodes/statistics', response_model=dict[str, t.Any])
+async def get_nodes_statistics(user: int | None = None) -> dict[str, t.Any]:
+    """Get statistics for nodes endpoint"""
+
+    from aiida.manage import get_manager
+
+    backend = get_manager().get_profile_storage()
+    return backend.query().get_creation_statistics(user_pk=user)
+
+
 @read_router.get('/nodes/download_formats')
 async def get_nodes_download_formats() -> dict[str, t.Any]:
     """Get download formats for AiiDA nodes.

--- a/aiida_restapi/routers/nodes.py
+++ b/aiida_restapi/routers/nodes.py
@@ -116,7 +116,25 @@ class NodeStatistics(pdt.BaseModel):
 @read_router.get('/nodes/statistics', response_model=NodeStatistics)
 @with_dbenv()
 async def get_nodes_statistics(user: int | None = None) -> dict[str, t.Any]:
-    """Get node statistics."""
+    """Get node statistics.
+
+    :param user: Optional user PK to filter statistics by user.
+    :return: A dictionary containing total node count, counts by node type, and creation time statistics.
+
+    >>> {
+    >>>   "total": 47,
+    >>>   "types": {
+    >>>       "data.core.int.Int.": 42,
+    >>>       "data.core.singlefile.SinglefileData.": 5,
+    >>>       ...
+    >>>   },
+    >>>   "ctime_by_day": {
+    >>>       "2012-01-01": 10,
+    >>>       "2012-01-02": 15,
+    >>>       ...
+    >>>   },
+    >>> }
+    """
 
     from aiida.manage import get_manager
 

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -642,8 +642,9 @@ async def test_get_download_node(async_client: AsyncClient, array_data_node: orm
     assert 'Please specify the download format' in response.json()['detail']
 
 
+@pytest.mark.usefixtures('default_nodes')
 @pytest.mark.anyio
-async def test_get_statistics(default_nodes, async_client):
+async def test_get_statistics(async_client: AsyncClient):
     """Test get statistics for nodes."""
 
     from datetime import datetime
@@ -659,7 +660,7 @@ async def test_get_statistics(default_nodes, async_client):
         'ctime_by_day': {datetime.today().strftime('%Y-%m-%d'): 4},
     }
 
-    # Test without specifiying user, should use default user
+    # Test without specifying user, should use default user
     response = await async_client.get('/nodes/statistics')
     assert response.status_code == 200, response.json()
     assert response.json() == default_user_reference_json

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -640,3 +640,39 @@ async def test_get_download_node(async_client: AsyncClient, array_data_node: orm
     response = await async_client.get(f'/nodes/{array_data_node.pk}/download')
     assert response.status_code == 422, response.json()
     assert 'Please specify the download format' in response.json()['detail']
+
+
+@pytest.mark.anyio
+async def test_get_statistics(default_nodes, async_client):
+    """Test get statistics for nodes."""
+
+    from datetime import datetime
+
+    default_user_reference_json = {
+        'total': 4,
+        'types': {
+            'data.core.float.Float.': 1,
+            'data.core.str.Str.': 1,
+            'data.core.bool.Bool.': 1,
+            'data.core.int.Int.': 1,
+        },
+        'ctime_by_day': {datetime.today().strftime('%Y-%m-%d'): 4},
+    }
+
+    # Test without specifiying user, should use default user
+    response = await async_client.get('/nodes/statistics')
+    assert response.status_code == 200, response.json()
+    assert response.json() == default_user_reference_json
+
+    # Test that the output is the same when we use the pk of the default user
+    from aiida import orm
+
+    default_user_pk = orm.User(email='').collection.get_default().pk
+    response = await async_client.get(f'/nodes/statistics?user={default_user_pk}')
+    assert response.status_code == 200, response.json()
+    assert response.json() == default_user_reference_json
+
+    # Test empty response for nonexisting user
+    response = await async_client.get('/nodes/statistics?user=99999')
+    assert response.status_code == 200, response.json()
+    assert response.json() == {'total': 0, 'types': {}, 'ctime_by_day': {}}


### PR DESCRIPTION
The implementation as in aiida-core. Using an explicit definition of node statistics for better API documentation.