### PR TITLE
Remove pull request event from fireing CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: ci
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
 


### PR DESCRIPTION
When opening a new PR the CI is run twice, once because the PR event is fired and once because the push even is raised. The push event is enough.