### PR TITLE
Upgrade documentation for migration to aiida-core 2.6

### DIFF
--- a/aiida_restapi/graphql/orm_factories.py
+++ b/aiida_restapi/graphql/orm_factories.py
@@ -31,9 +31,10 @@ _type_mapping = {
 
 def get_pydantic_type_name(annotation: Any) -> Any:
     """
-    In pydantic v1, one could do field.type_,
+    In pydantic v1, one could do `field.type_`,
     but in v2, one has to go though field.annotation
     """
+
     args = typing.get_args(annotation)
     if args:
         return args[0]

--- a/aiida_restapi/graphql/sphinx_ext.py
+++ b/aiida_restapi/graphql/sphinx_ext.py
@@ -3,7 +3,7 @@
 # pylint: disable=import-outside-toplevel
 from typing import TYPE_CHECKING, List
 
-from graphql.utils.schema_printer import print_schema
+from graphql.utilities import print_schema
 
 from .main import SCHEMA
 
@@ -21,7 +21,7 @@ def setup(app: 'Sphinx') -> None:
 
         def run(self) -> List[Element]:
             """Run the directive."""
-            text = print_schema(SCHEMA)
+            text = print_schema(SCHEMA.graphql_schema)
             # TODO for lexing tried: https://gitlab.com/marcogiusti/pygments-graphql/-/blob/master/src/pygments_graphql.py
             # but it failed
             code_node = literal_block(text, text)  # , language="graphql")

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,15 +14,7 @@ import os
 import sys
 import time
 
-from aiida.manage.configuration import load_documentation_profile
-
 import aiida_restapi
-
-# -- AiiDA-related setup --------------------------------------------------
-
-# Load the dummy profile even if we are running locally, this way the documentation will succeed even if the current
-# default profile of the AiiDA installation does not use a Django backend.
-load_documentation_profile()
 
 extensions = [
     'myst_parser',


### PR DESCRIPTION
Remove usage of `load_documentation_profile` in docs. With aiida-core/pull/6226 the usage of load_documentation_profile is not anymore required as the Django backend is not anymore supported and can therefore be removed.

graphql.utils has been moved to graphql.utilities