### PR TITLE
Reintroduce `pull_request` in GitHub workflow with if case

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,12 @@
 name: ci
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
 
   pre-commit:
+    # runs only on pull request when from foreign repo, prevents duplicate runs
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
 
     runs-on: ubuntu-latest
 
@@ -19,6 +21,8 @@ jobs:
     - uses: pre-commit/action@v2.0.0
 
   tests:
+    # runs only on pull request when from foreign repo, prevents duplicate runs
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
 
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
I ran in PR https://github.com/aiidateam/aiida-restapi/pull/73 in the problem that the CI was not run, so I added this. I think aiida-core it does not show the pull_request events that are cancelled as in this PR, but I am not sure how it is done it there. 

The disadvantage of removing the `pull_request` as trigger event for an GitHub workflow is that it does not trigger for pushes from a foreign repo. To run the workflow also in this case without running the workflow twice for PRs based on the original repo we introduce an if case that runs the `pull_request` event only when it from a foreign repo.

See https://wildwolf.name/github-actions-how-to-avoid-running-the-same-workflow-multiple-times/ for more explanation