### PR TITLE
Read-only mode

### DIFF
--- a/aiida_restapi/__init__.py
+++ b/aiida_restapi/__init__.py
@@ -1,5 +1,3 @@
-"""AiiDA REST API for data queries and workflow managment."""
+"""AiiDA REST API for data queries and workflow management."""
 
 __version__ = '0.1.0a1'
-
-from .main import app  # noqa: F401

--- a/aiida_restapi/cli/main.py
+++ b/aiida_restapi/cli/main.py
@@ -1,0 +1,31 @@
+import os
+
+import click
+import uvicorn
+
+
+@click.group()
+def cli() -> None:
+    """AiiDA REST API management CLI."""
+
+
+@cli.command()
+@click.option('--host', default='127.0.0.1', show_default=True)
+@click.option('--port', default=8000, show_default=True, type=int)
+@click.option('--read-only', is_flag=True)
+@click.option('--watch', is_flag=True)
+def start(read_only: bool, watch: bool, host: str, port: int) -> None:
+    """Start the AiiDA REST API service."""
+
+    os.environ['AIIDA_RESTAPI_READ_ONLY'] = '1' if read_only else '0'
+
+    click.echo(f'Starting REST API (read_only={read_only}, watch={watch}) on {host}:{port}')
+
+    uvicorn.run(
+        'aiida_restapi.main:create_app',
+        host=host,
+        port=port,
+        reload=watch,
+        reload_dirs=['aiida_restapi'],
+        factory=True,
+    )

--- a/aiida_restapi/main.py
+++ b/aiida_restapi/main.py
@@ -1,5 +1,8 @@
 """Declaration of FastAPI application."""
 
+import os
+import typing as t
+
 from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse
 
@@ -7,26 +10,36 @@ from aiida_restapi.graphql import main
 from aiida_restapi.routers import auth, computers, daemon, groups, nodes, submit, users
 from aiida_restapi.utils import generate_endpoints_table
 
-app = FastAPI()
+
+def generate_endpoints_table_endpoint(app: FastAPI) -> t.Callable[[Request], HTMLResponse]:
+    """Generate an endpoint that lists all registered API routes."""
+
+    def list_endpoints(request: Request) -> HTMLResponse:
+        """Return an HTML table of all registered API routes."""
+        return HTMLResponse(
+            content=generate_endpoints_table(
+                str(request.base_url).rstrip('/'),
+                app.routes,
+            ),
+        )
+
+    return list_endpoints
 
 
-@app.get('/', response_class=HTMLResponse)
-def list_endpoints(request: Request) -> HTMLResponse:
-    """Return an HTML table of all registered API routes."""
-    return HTMLResponse(
-        content=generate_endpoints_table(
-            str(request.base_url).rstrip('/'),
-            app.routes,
-        ),
-    )
+def create_app() -> FastAPI:
+    """Create the FastAPI application and include the routers."""
 
+    read_only = os.getenv('AIIDA_RESTAPI_READ_ONLY') == '1'
 
-app.include_router(auth.router)
-app.include_router(computers.router)
-app.include_router(daemon.router)
-app.include_router(nodes.router)
-app.include_router(groups.router)
-app.include_router(users.router)
-app.include_router(submit.router)
+    app = FastAPI()
 
-app.add_route('/graphql', main.app, name='graphql', methods=['POST'])
+    for module in (auth, computers, daemon, groups, nodes, submit, users):
+        if read_router := getattr(module, 'read_router', None):
+            app.include_router(read_router)
+        if not read_only and (write_router := getattr(module, 'write_router', None)):
+            app.include_router(write_router)
+
+    app.add_route('/graphql', main.app)
+    app.add_route('/', lambda request: generate_endpoints_table_endpoint(app)(request))
+
+    return app

--- a/aiida_restapi/routers/auth.py
+++ b/aiida_restapi/routers/auth.py
@@ -35,7 +35,8 @@ pwd_context = PasswordHasher()
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl='token')
 
-router = APIRouter()
+read_router = APIRouter()
+write_router = APIRouter()
 
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
@@ -113,7 +114,7 @@ async def get_current_active_user(
     return current_user
 
 
-@router.post('/token', response_model=Token)
+@write_router.post('/token', response_model=Token)
 async def login_for_access_token(
     form_data: OAuth2PasswordRequestForm = Depends(),
 ) -> dict[str, t.Any]:
@@ -130,7 +131,7 @@ async def login_for_access_token(
     return {'access_token': access_token, 'token_type': 'bearer'}
 
 
-@router.get('/auth/me/', response_model=orm.User.Model)
+@read_router.get('/auth/me/', response_model=orm.User.Model)
 async def read_users_me(
     current_user: t.Annotated[orm.User.Model, Depends(get_current_active_user)],
 ) -> orm.User.Model:

--- a/aiida_restapi/routers/computers.py
+++ b/aiida_restapi/routers/computers.py
@@ -15,12 +15,13 @@ from aiida_restapi.repository.entity import EntityRepository
 
 from .auth import UserInDB, get_current_active_user
 
-router = APIRouter()
+read_router = APIRouter()
+write_router = APIRouter()
 
 repository = EntityRepository[orm.Computer, orm.Computer.Model](orm.Computer)
 
 
-@router.get('/computers/schema')
+@read_router.get('/computers/schema')
 async def get_computers_schema(
     which: t.Literal['get', 'post'] = Query(
         'get',
@@ -39,7 +40,7 @@ async def get_computers_schema(
         raise HTTPException(status_code=422, detail=str(err)) from err
 
 
-@router.get('/computers/projectable_properties', response_model=list[str])
+@read_router.get('/computers/projectable_properties', response_model=list[str])
 async def get_computer_projectable_properties() -> list[str]:
     """Get projectable properties for AiiDA computers.
 
@@ -48,7 +49,7 @@ async def get_computer_projectable_properties() -> list[str]:
     return repository.get_projectable_properties()
 
 
-@router.get(
+@read_router.get(
     '/computers',
     response_model=PaginatedResults[orm.Computer.Model],
     response_model_exclude_none=True,
@@ -66,7 +67,7 @@ async def get_computers(
     return repository.get_entities(queries)
 
 
-@router.get(
+@read_router.get(
     '/computers/{computer_id}',
     response_model=orm.Computer.Model,
     response_model_exclude_none=True,
@@ -86,7 +87,7 @@ async def get_computer(computer_id: int) -> orm.Computer.Model:
         raise HTTPException(status_code=404, detail=f'Could not find a Computer with id {computer_id}')
 
 
-@router.get('/computers/{computer_id}/metadata', response_model=dict[str, t.Any])
+@read_router.get('/computers/{computer_id}/metadata', response_model=dict[str, t.Any])
 @with_dbenv()
 async def get_computer_metadata(computer_id: int) -> dict[str, t.Any]:
     """Get metadata of an AiiDA computer by id.
@@ -102,7 +103,7 @@ async def get_computer_metadata(computer_id: int) -> dict[str, t.Any]:
         raise HTTPException(status_code=404, detail=f'Could not find a Computer with id {computer_id}')
 
 
-@router.post(
+@write_router.post(
     '/computers',
     response_model=orm.Computer.Model,
     response_model_exclude_none=True,

--- a/aiida_restapi/routers/daemon.py
+++ b/aiida_restapi/routers/daemon.py
@@ -11,7 +11,8 @@ from pydantic import BaseModel, Field
 
 from .auth import UserInDB, get_current_active_user
 
-router = APIRouter()
+read_router = APIRouter()
+write_router = APIRouter()
 
 
 class DaemonStatusModel(BaseModel):
@@ -21,7 +22,7 @@ class DaemonStatusModel(BaseModel):
     num_workers: t.Optional[int] = Field(description='The number of workers if the daemon is running.')
 
 
-@router.get(
+@read_router.get(
     '/daemon/status',
     response_model=DaemonStatusModel,
 )
@@ -44,7 +45,7 @@ async def get_daemon_status() -> DaemonStatusModel:
     return DaemonStatusModel(running=True, num_workers=response['numprocesses'])
 
 
-@router.post(
+@write_router.post(
     '/daemon/start',
     response_model=DaemonStatusModel,
 )
@@ -71,7 +72,7 @@ async def get_daemon_start(
     return DaemonStatusModel(running=True, num_workers=response['numprocesses'])
 
 
-@router.post(
+@write_router.post(
     '/daemon/stop',
     response_model=DaemonStatusModel,
 )

--- a/aiida_restapi/routers/groups.py
+++ b/aiida_restapi/routers/groups.py
@@ -15,12 +15,13 @@ from aiida_restapi.repository.entity import EntityRepository
 
 from .auth import UserInDB, get_current_active_user
 
-router = APIRouter()
+read_router = APIRouter()
+write_router = APIRouter()
 
 repository = EntityRepository[orm.Group, orm.Group.Model](orm.Group)
 
 
-@router.get('/groups/schema')
+@read_router.get('/groups/schema')
 async def get_groups_schema(
     which: t.Literal['get', 'post'] = Query(
         'get',
@@ -39,7 +40,7 @@ async def get_groups_schema(
         raise HTTPException(status_code=422, detail=str(err)) from err
 
 
-@router.get('/groups/projectable_properties', response_model=list[str])
+@read_router.get('/groups/projectable_properties', response_model=list[str])
 async def get_group_projectable_properties() -> list[str]:
     """Get projectable properties for AiiDA groups.
 
@@ -48,7 +49,7 @@ async def get_group_projectable_properties() -> list[str]:
     return repository.get_projectable_properties()
 
 
-@router.get(
+@read_router.get(
     '/groups',
     response_model=PaginatedResults[orm.Group.Model],
     response_model_exclude_none=True,
@@ -66,7 +67,7 @@ async def get_groups(
     return repository.get_entities(queries)
 
 
-@router.get(
+@read_router.get(
     '/groups/{group_id}',
     response_model=orm.Group.Model,
     response_model_exclude_none=True,
@@ -89,7 +90,7 @@ async def get_group(group_id: int) -> orm.Group.Model:
         raise HTTPException(status_code=500, detail=str(err))
 
 
-@router.get(
+@read_router.get(
     '/groups/{group_id}/extras',
     response_model=dict[str, t.Any],
 )
@@ -110,7 +111,7 @@ async def get_group_extras(group_id: int) -> dict[str, t.Any]:
         raise HTTPException(status_code=500, detail=str(err)) from err
 
 
-@router.post(
+@write_router.post(
     '/groups',
     response_model=orm.Group.Model,
     response_model_exclude_none=True,

--- a/aiida_restapi/routers/nodes.py
+++ b/aiida_restapi/routers/nodes.py
@@ -21,7 +21,8 @@ from aiida_restapi.repository.node import NodeRepository
 
 from .auth import UserInDB, get_current_active_user
 
-router = APIRouter()
+read_router = APIRouter()
+write_router = APIRouter()
 
 repository = NodeRepository[orm.Node, orm.Node.Model](orm.Node)
 model_registry = NodeModelRegistry()
@@ -34,7 +35,7 @@ else:
     NodeModelUnion = model_registry.ModelUnion
 
 
-@router.get('/nodes/schema')
+@read_router.get('/nodes/schema')
 async def get_nodes_schema(
     node_type: str | None = Query(
         None,
@@ -63,7 +64,7 @@ async def get_nodes_schema(
         raise HTTPException(status_code=422, detail=str(exception)) from exception
 
 
-@router.get('/nodes/projectable_properties')
+@read_router.get('/nodes/projectable_properties')
 @with_dbenv()
 async def get_node_projectable_properties(
     node_type: str | None = Query(
@@ -84,7 +85,7 @@ async def get_node_projectable_properties(
         raise HTTPException(status_code=422, detail=str(err)) from err
 
 
-@router.get('/nodes/download_formats')
+@read_router.get('/nodes/download_formats')
 async def get_nodes_download_formats() -> dict[str, t.Any]:
     """Get download formats for AiiDA nodes.
 
@@ -100,7 +101,7 @@ async def get_nodes_download_formats() -> dict[str, t.Any]:
         raise HTTPException(status_code=500, detail=str(err)) from err
 
 
-@router.get(
+@read_router.get(
     '/nodes',
     response_model=PaginatedResults[orm.Node.Model],
     response_model_exclude_none=True,
@@ -128,7 +129,7 @@ class NodeType(pdt.BaseModel):
     node_schema: str = pdt.Field(description='The URL to access the schema of this node type.')
 
 
-@router.get('/nodes/types', response_model=list[NodeType])
+@read_router.get('/nodes/types', response_model=list[NodeType])
 async def get_node_types() -> list:
     """Get all node types in machine-actionable format.
 
@@ -159,7 +160,7 @@ async def get_node_types() -> list:
     ]
 
 
-@router.get(
+@read_router.get(
     '/nodes/{node_id}',
     response_model=orm.Node.Model,
     response_model_exclude_none=True,
@@ -182,7 +183,7 @@ async def get_node(node_id: int) -> orm.Node.Model:
         raise HTTPException(status_code=500, detail=str(err)) from err
 
 
-@router.get(
+@read_router.get(
     '/nodes/{node_id}/attributes',
     response_model=dict[str, t.Any],
 )
@@ -203,7 +204,7 @@ async def get_node_attributes(node_id: int) -> dict[str, t.Any]:
         raise HTTPException(status_code=500, detail=str(err)) from err
 
 
-@router.get(
+@read_router.get(
     '/nodes/{node_id}/extras',
     response_model=dict[str, t.Any],
 )
@@ -224,7 +225,7 @@ async def get_node_extras(node_id: int) -> dict[str, t.Any]:
         raise HTTPException(status_code=500, detail=str(err)) from err
 
 
-@router.get('/nodes/{node_id}/download')
+@read_router.get('/nodes/{node_id}/download')
 @with_dbenv()
 async def download_node(
     node_id: int,
@@ -307,7 +308,7 @@ class RepoDirMetadata(pdt.BaseModel):
 MetadataType = t.Union[RepoFileMetadata, RepoDirMetadata]
 
 
-@router.get(
+@read_router.get(
     '/nodes/{node_id}/repo/metadata',
     response_model=dict[str, MetadataType],
 )
@@ -328,7 +329,7 @@ async def get_node_repo_file_metadata(node_id: int) -> dict[str, dict]:
         raise HTTPException(status_code=500, detail=str(err)) from err
 
 
-@router.get('/nodes/{node_id}/repo/contents')
+@read_router.get('/nodes/{node_id}/repo/contents')
 @with_dbenv()
 async def get_node_repo_file_contents(
     node_id: int,
@@ -384,7 +385,7 @@ async def get_node_repo_file_contents(
         return StreamingResponse(zip_stream(), media_type='application/zip', headers=headers)
 
 
-@router.post(
+@write_router.post(
     '/nodes',
     response_model=orm.Node.Model,
     response_model_exclude_none=True,
@@ -411,7 +412,7 @@ async def create_node(
         raise HTTPException(status_code=500, detail=str(exception)) from exception
 
 
-@router.post(
+@write_router.post(
     '/nodes/file-upload',
     response_model=orm.Node.Model,
     response_model_exclude_none=True,

--- a/aiida_restapi/routers/submit.py
+++ b/aiida_restapi/routers/submit.py
@@ -13,7 +13,7 @@ from fastapi import APIRouter, Depends, HTTPException
 
 from .auth import UserInDB, get_current_active_user
 
-router = APIRouter()
+write_router = APIRouter()
 
 
 def process_inputs(inputs: dict[str, t.Any]) -> dict[str, t.Any]:
@@ -58,7 +58,7 @@ class ProcessSubmitModel(pdt.BaseModel):
         return process_inputs(inputs)
 
 
-@router.post(
+@write_router.post(
     '/submit',
     response_model=orm.Node.Model,
     response_model_exclude_none=True,

--- a/aiida_restapi/routers/users.py
+++ b/aiida_restapi/routers/users.py
@@ -15,12 +15,13 @@ from aiida_restapi.repository.entity import EntityRepository
 
 from .auth import UserInDB, get_current_active_user
 
-router = APIRouter()
+read_router = APIRouter()
+write_router = APIRouter()
 
 repository = EntityRepository[orm.User, orm.User.Model](orm.User)
 
 
-@router.get('/users/schema')
+@read_router.get('/users/schema')
 async def get_users_schema(
     which: t.Literal['get', 'post'] = Query(
         'get',
@@ -39,7 +40,7 @@ async def get_users_schema(
         raise HTTPException(status_code=422, detail=str(err)) from err
 
 
-@router.get('/users/projectable_properties', response_model=list[str])
+@read_router.get('/users/projectable_properties', response_model=list[str])
 async def get_user_projectable_properties() -> list[str]:
     """Get projectable properties for AiiDA user.
 
@@ -48,7 +49,7 @@ async def get_user_projectable_properties() -> list[str]:
     return repository.get_projectable_properties()
 
 
-@router.get(
+@read_router.get(
     '/users',
     response_model=PaginatedResults[orm.User.Model],
     response_model_exclude_none=True,
@@ -66,7 +67,7 @@ async def get_users(
     return repository.get_entities(queries)
 
 
-@router.get(
+@read_router.get(
     '/users/{user_id}',
     response_model=orm.User.Model,
 )
@@ -84,7 +85,7 @@ async def get_user(user_id: int) -> orm.User.Model:
         raise HTTPException(status_code=404, detail=f'Could not find a User with id {user_id}')
 
 
-@router.post(
+@write_router.post(
     '/users',
     response_model=orm.User.Model,
     response_model_exclude_none=True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,9 @@ testing = [
   'anyio~=4.6.0',
 ]
 
+[project.scripts]
+aiida-restapi = 'aiida_restapi.cli.main:cli'
+
 [project.urls]
 Source = 'https://github.com/aiidateam/aiida-restapi'
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,12 @@
+# test main application
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def test_read_only_mode(read_only_app: FastAPI):
+    client = TestClient(read_only_app)
+    response = client.get('/computers/')
+    assert response.status_code == 200
+    response = client.post('/computers/', json={'name': 'new_computer'})
+    assert response.status_code == 405

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -233,13 +233,16 @@ def test_create_dict(client: TestClient):
 async def test_create_code(async_client: AsyncClient, default_computers: list[int | None]):
     """Test creating a new Code."""
     for comp_id in default_computers:
+        computer = orm.load_computer(comp_id)
         response = await async_client.post(
             '/nodes',
             json={
                 'node_type': 'data.core.code.installed.InstalledCode.',
                 'label': 'test_code',
-                'computer': comp_id,
-                'attributes': {'filepath_executable': '/bin/true'},
+                'attributes': {
+                    'filepath_executable': '/bin/true',
+                    'computer': computer.label,
+                },
             },
         )
     assert response.status_code == 200, response.content


### PR DESCRIPTION
Supersedes #65 

This PR takes a different approach to #65. It implements a read-only API by way of separating read/write endpoints to read/write routers, only serving the former in --read-only mode.

The PR also adds a CLI for easy API launch.

Closes #63 
Closes #86 