### PR TITLE
Switch from pk to uuid (except for users)

### DIFF
--- a/aiida_restapi/repository/node.py
+++ b/aiida_restapi/repository/node.py
@@ -74,13 +74,13 @@ class NodeRepository(EntityRepository[NodeType, NodeModelType]):
 
         return all_formats
 
-    def get_node_repository_metadata(self, node_id: int) -> dict[str, dict]:
+    def get_node_repository_metadata(self, uuid: str) -> dict[str, dict]:
         """Get the repository metadata of a node.
 
-        :param node_id: The id of the node to retrieve the repository metadata for.
+        :param uuid: The uuid of the node to retrieve the repository metadata for.
         :return: A dictionary with the repository file metadata.
         """
-        node = self.entity_class.collection.get(pk=node_id)
+        node = self.entity_class.collection.get(uuid=uuid)
         total_size = 0
 
         def get_metadata(objects: list[File], path: str | None = None) -> dict[str, dict]:
@@ -113,7 +113,7 @@ class NodeRepository(EntityRepository[NodeType, NodeModelType]):
                         'type': 'FILE',
                         'binary': binary,
                         'size': size,
-                        'download': f'/nodes/{node_id}/repo/contents?filename={obj_name}',
+                        'download': f'/nodes/{uuid}/repo/contents?filename={obj_name}',
                     }
                     total_size += size
 
@@ -126,39 +126,39 @@ class NodeRepository(EntityRepository[NodeType, NodeModelType]):
                 'type': 'FILE',
                 'binary': True,
                 'size': total_size,
-                'download': f'/nodes/{node_id}/repo/contents',
+                'download': f'/nodes/{uuid}/repo/contents',
             }
 
         return metadata
 
-    def get_node_attributes(self, node_id: int) -> dict[str, t.Any]:
+    def get_node_attributes(self, uuid: str) -> dict[str, t.Any]:
         """Get the attributes of a node.
 
-        :param node_id: The id of the node to retrieve the attributes for.
+        :param uuid: The uuid of the node to retrieve the attributes for.
         :return: A dictionary with the node attributes.
         """
         return t.cast(
             dict,
             self.entity_class.collection.query(
-                filters={'pk': node_id},
+                filters={'uuid': uuid},
                 project=['attributes'],
             ).first()[0],
         )
 
     def get_node_links(
         self,
-        node_id: int,
+        uuid: str,
         queries: QueryParams,
         direction: t.Literal['incoming', 'outgoing'],
     ) -> PaginatedResults[NodeLinks]:
         """Get the incoming links of a node.
 
-        :param node_id: The id of the node to retrieve the incoming links for.
+        :param uuid: The uuid of the node to retrieve the incoming links for.
         :param queries: The query parameters, including filters, order_by, page_size, and page.
         :param direction: Specify whether to retrieve incoming or outgoing links.
         :return: The paginated requested linked nodes.
         """
-        node = self.entity_class.collection.get(pk=node_id)
+        node = self.entity_class.collection.get(uuid=uuid)
 
         if direction == 'incoming':
             link_collection = node.base.links.get_incoming()

--- a/aiida_restapi/routers/computers.py
+++ b/aiida_restapi/routers/computers.py
@@ -32,12 +32,15 @@ async def get_computers_schema(
 
     :param which: The type of schema to retrieve: 'get' or 'post'.
     :return: A dictionary with 'get' and 'post' keys containing the respective JSON schemas.
-    :raises HTTPException: 422 if the 'which' parameter is not 'get' or 'post'.
+    :raises HTTPException: 422 if the 'which' parameter is not 'get' or 'post',
+        500 for any other failures.
     """
     try:
         return repository.get_entity_schema(which=which)
-    except ValueError as err:
-        raise HTTPException(status_code=422, detail=str(err)) from err
+    except ValueError as exception:
+        raise HTTPException(status_code=422, detail=str(exception)) from exception
+    except Exception as exception:
+        raise HTTPException(status_code=500, detail=str(exception)) from exception
 
 
 @read_router.get('/computers/projectable_properties', response_model=list[str])
@@ -68,39 +71,45 @@ async def get_computers(
 
 
 @read_router.get(
-    '/computers/{computer_id}',
+    '/computers/{pk}',
     response_model=orm.Computer.Model,
     response_model_exclude_none=True,
     response_model_exclude_unset=True,
 )
 @with_dbenv()
-async def get_computer(computer_id: int) -> orm.Computer.Model:
-    """Get AiiDA computer by id.
+async def get_computer(pk: str) -> orm.Computer.Model:
+    """Get AiiDA computer by pk.
 
-    :param computer_id: The id of the AiiDA computer.
+    :param pk: The pk of the AiiDA computer.
     :return: The computer model.
-    :raises HTTPException: 404 if the computer with the given id does not exist.
+    :raises HTTPException: 404 if the computer with the given pk does not exist,
+        500 for any other failures.
     """
     try:
-        return repository.get_entity_by_id(computer_id)
-    except NotExistent:
-        raise HTTPException(status_code=404, detail=f'Could not find a Computer with id {computer_id}')
+        return repository.get_entity_by_id(pk)
+    except NotExistent as exception:
+        raise HTTPException(status_code=404, detail=str(exception)) from exception
+    except Exception as exception:
+        raise HTTPException(status_code=500, detail=str(exception)) from exception
 
 
-@read_router.get('/computers/{computer_id}/metadata', response_model=dict[str, t.Any])
+@read_router.get('/computers/{pk}/metadata', response_model=dict[str, t.Any])
 @with_dbenv()
-async def get_computer_metadata(computer_id: int) -> dict[str, t.Any]:
-    """Get metadata of an AiiDA computer by id.
+async def get_computer_metadata(pk: str) -> dict[str, t.Any]:
+    """Get metadata of an AiiDA computer by pk.
 
-    :param computer_id: The id of the AiiDA computer.
+    :param pk: The pk of the AiiDA computer.
     :return: The metadata dictionary of the computer.
-    :raises HTTPException: 404 if the computer with the given id does not exist.
+    :raises HTTPException: 404 if the computer with the given pk does not exist,
+        500 for any other failures.
     """
     try:
-        computer = repository.get_entity_by_id(computer_id)
+        computer = repository.get_entity_by_id(pk)
         return computer.metadata
-    except NotExistent:
-        raise HTTPException(status_code=404, detail=f'Could not find a Computer with id {computer_id}')
+    except NotExistent as exception:
+        raise HTTPException(status_code=404, detail=str(exception)) from exception
+    except Exception as exception:
+        raise HTTPException(status_code=500, detail=str(exception)) from exception
 
 
 @write_router.post(
@@ -123,5 +132,5 @@ async def create_computer(
     """
     try:
         return repository.create_entity(computer_model)
-    except Exception as err:
-        raise HTTPException(status_code=500, detail=str(err))
+    except Exception as exception:
+        raise HTTPException(status_code=500, detail=str(exception))

--- a/aiida_restapi/routers/groups.py
+++ b/aiida_restapi/routers/groups.py
@@ -32,12 +32,15 @@ async def get_groups_schema(
 
     :param which: The type of schema to retrieve: 'get' or 'post'.
     :return: A dictionary with 'get' and 'post' keys containing the respective JSON schemas.
-    :raises HTTPException: 422 if the 'which' parameter is not 'get' or 'post'.
+    :raises HTTPException: 422 if the 'which' parameter is not 'get' or 'post',
+        500 for any other failures.
     """
     try:
         return repository.get_entity_schema(which=which)
-    except ValueError as err:
-        raise HTTPException(status_code=422, detail=str(err)) from err
+    except ValueError as exception:
+        raise HTTPException(status_code=422, detail=str(exception)) from exception
+    except Exception as exception:
+        raise HTTPException(status_code=500, detail=str(exception)) from exception
 
 
 @read_router.get('/groups/projectable_properties', response_model=list[str])
@@ -68,47 +71,47 @@ async def get_groups(
 
 
 @read_router.get(
-    '/groups/{group_id}',
+    '/groups/{uuid}',
     response_model=orm.Group.Model,
     response_model_exclude_none=True,
     response_model_exclude_unset=True,
 )
 @with_dbenv()
-async def get_group(group_id: int) -> orm.Group.Model:
-    """Get AiiDA group by id.
+async def get_group(uuid: str) -> orm.Group.Model:
+    """Get AiiDA group by uuid.
 
-    :param group_id: The id of the group to retrieve.
+    :param uuid: The uuid of the group to retrieve.
     :return: The AiiDA group model.
-    :raises HTTPException: 404 if a group with the given id does not exist,
+    :raises HTTPException: 404 if a group with the given uuid does not exist,
         500 for any other server error.
     """
     try:
-        return repository.get_entity_by_id(group_id)
-    except NotExistent:
-        raise HTTPException(status_code=404, detail=f'Could not find a Group with id {group_id}')
-    except Exception as err:
-        raise HTTPException(status_code=500, detail=str(err))
+        return repository.get_entity_by_id(uuid)
+    except NotExistent as exception:
+        raise HTTPException(status_code=404, detail=str(exception)) from exception
+    except Exception as exception:
+        raise HTTPException(status_code=500, detail=str(exception)) from exception
 
 
 @read_router.get(
-    '/groups/{group_id}/extras',
+    '/groups/{uuid}/extras',
     response_model=dict[str, t.Any],
 )
 @with_dbenv()
-async def get_group_extras(group_id: int) -> dict[str, t.Any]:
+async def get_group_extras(uuid: str) -> dict[str, t.Any]:
     """Get the extras of a group.
 
-    :param group_id: The id of the group to retrieve the extras for.
+    :param uuid: The uuid of the group to retrieve the extras for.
     :return: A dictionary with the group extras.
-    :raises HTTPException: 404 if the group with the given id does not exist,
+    :raises HTTPException: 404 if the group with the given uuid does not exist,
         500 for other failures during retrieval.
     """
     try:
-        return repository.get_entity_extras(group_id)
-    except NotExistent:
-        raise HTTPException(status_code=404, detail=f'Could not find any group with id {group_id}')
-    except Exception as err:
-        raise HTTPException(status_code=500, detail=str(err)) from err
+        return repository.get_entity_extras(uuid)
+    except NotExistent as exception:
+        raise HTTPException(status_code=404, detail=str(exception)) from exception
+    except Exception as exception:
+        raise HTTPException(status_code=500, detail=str(exception)) from exception
 
 
 @write_router.post(
@@ -131,5 +134,5 @@ async def create_group(
     """
     try:
         return repository.create_entity(group_model)
-    except Exception as err:
-        raise HTTPException(status_code=500, detail=str(err))
+    except Exception as exception:
+        raise HTTPException(status_code=500, detail=str(exception)) from exception

--- a/aiida_restapi/routers/nodes.py
+++ b/aiida_restapi/routers/nodes.py
@@ -26,6 +26,7 @@ read_router = APIRouter()
 write_router = APIRouter()
 
 repository = NodeRepository[orm.Node, orm.Node.Model](orm.Node)
+
 model_registry = NodeModelRegistry()
 
 if t.TYPE_CHECKING:
@@ -54,7 +55,8 @@ async def get_nodes_schema(
     :param which: The type of schema to retrieve: 'get' or 'post'.
     :return: The JSON schema for the base AiiDA node 'get' model.
     :raises HTTPException: 422 if the 'which' parameter is not 'get' or 'post',
-        422 if the node type is not recognized.
+        422 if the node type is not recognized,
+        500 for any other failures.
     """
     if not node_type:
         return orm.Node.Model.model_json_schema()
@@ -63,6 +65,8 @@ async def get_nodes_schema(
         return model.model_json_schema()
     except KeyError as exception:
         raise HTTPException(status_code=422, detail=str(exception)) from exception
+    except Exception as exception:
+        raise HTTPException(status_code=500, detail=str(exception)) from exception
 
 
 @read_router.get('/nodes/projectable_properties')
@@ -78,12 +82,15 @@ async def get_node_projectable_properties(
 
     :param node_type: The AiiDA node type string.
     :return: The list of projectable properties for AiiDA nodes.
-    :raises HTTPException: 422 if the node type is not recognized.
+    :raises HTTPException: 422 if the node type is not recognized,
+        500 for any other failures.
     """
     try:
         return repository.get_projectable_properties(node_type)
-    except ValueError as err:
-        raise HTTPException(status_code=422, detail=str(err)) from err
+    except ValueError as exception:
+        raise HTTPException(status_code=422, detail=str(exception)) from exception
+    except Exception as exception:
+        raise HTTPException(status_code=500, detail=str(exception)) from exception
 
 
 class NodeStatistics(pdt.BaseModel):
@@ -152,10 +159,10 @@ async def get_nodes_download_formats() -> dict[str, t.Any]:
     """
     try:
         return repository.get_all_download_formats()
-    except EntryPointError:
-        raise HTTPException(status_code=404, detail='The download formats are not available.')
-    except Exception as err:
-        raise HTTPException(status_code=500, detail=str(err)) from err
+    except EntryPointError as exception:
+        raise HTTPException(status_code=404, detail=str(exception)) from exception
+    except Exception as exception:
+        raise HTTPException(status_code=500, detail=str(exception)) from exception
 
 
 @read_router.get(
@@ -219,79 +226,79 @@ async def get_node_types() -> list:
 
 
 @read_router.get(
-    '/nodes/{node_id}',
+    '/nodes/{uuid}',
     response_model=orm.Node.Model,
     response_model_exclude_none=True,
     response_model_exclude_unset=True,
 )
 @with_dbenv()
-async def get_node(node_id: int) -> orm.Node.Model:
-    """Get AiiDA node by id.
+async def get_node(uuid: str) -> orm.Node.Model:
+    """Get AiiDA node by uuid.
 
-    :param node_id: The id of the node to retrieve.
+    :param uuid: The uuid of the node to retrieve.
     :return: The AiiDA node model, e.g. `orm.Node.Model`,
-    :raises HTTPException: 422 if the node with the given id does not exist,
+    :raises HTTPException: 422 if the node with the given uuid does not exist,
         500 for other failures during retrieval.
     """
     try:
-        return repository.get_entity_by_id(node_id)
-    except NotExistent:
-        raise HTTPException(status_code=422, detail=f'Could not find any Node with id {node_id}')
-    except Exception as err:
-        raise HTTPException(status_code=500, detail=str(err)) from err
+        return repository.get_entity_by_id(uuid)
+    except NotExistent as exception:
+        raise HTTPException(status_code=422, detail=str(exception)) from exception
+    except Exception as exception:
+        raise HTTPException(status_code=500, detail=str(exception)) from exception
 
 
 @read_router.get(
-    '/nodes/{node_id}/attributes',
+    '/nodes/{uuid}/attributes',
     response_model=dict[str, t.Any],
 )
 @with_dbenv()
-async def get_node_attributes(node_id: int) -> dict[str, t.Any]:
+async def get_node_attributes(uuid: str) -> dict[str, t.Any]:
     """Get the attributes of a node.
 
-    :param node_id: The id of the node to retrieve the attributes for.
+    :param uuid: The uuid of the node to retrieve the attributes for.
     :return: A dictionary with the node attributes.
-    :raises HTTPException: 404 if the node with the given id does not exist,
+    :raises HTTPException: 404 if the node with the given uuid does not exist,
         500 for other failures during retrieval.
     """
     try:
-        return repository.get_node_attributes(node_id)
-    except NotExistent:
-        raise HTTPException(status_code=404, detail=f'Could not find any node with id {node_id}')
-    except Exception as err:
-        raise HTTPException(status_code=500, detail=str(err)) from err
+        return repository.get_node_attributes(uuid)
+    except NotExistent as exception:
+        raise HTTPException(status_code=404, detail=str(exception)) from exception
+    except Exception as exception:
+        raise HTTPException(status_code=500, detail=str(exception)) from exception
 
 
 @read_router.get(
-    '/nodes/{node_id}/extras',
+    '/nodes/{uuid}/extras',
     response_model=dict[str, t.Any],
 )
 @with_dbenv()
-async def get_node_extras(node_id: int) -> dict[str, t.Any]:
+async def get_node_extras(uuid: str) -> dict[str, t.Any]:
     """Get the extras of a node.
 
-    :param node_id: The id of the node to retrieve the extras for.
+    :param uuid: The uuid of the node to retrieve the extras for.
     :return: A dictionary with the node extras.
-    :raises HTTPException: 404 if the node with the given id does not exist,
+    :raises HTTPException: 404 if the node with the given uuid does not exist,
         500 for other failures during retrieval.
     """
     try:
-        return repository.get_entity_extras(node_id)
-    except NotExistent:
-        raise HTTPException(status_code=404, detail=f'Could not find any node with id {node_id}')
-    except Exception as err:
-        raise HTTPException(status_code=500, detail=str(err)) from err
+        return repository.get_entity_extras(uuid)
+    except NotExistent as exception:
+        raise HTTPException(status_code=404, detail=str(exception)) from exception
+    except Exception as exception:
+        raise HTTPException(status_code=500, detail=str(exception)) from exception
 
 
 @read_router.get(
-    '/nodes/{node_id}/links',
+    '/nodes/{uuid}/links',
     response_model=PaginatedResults[NodeLinks],
     response_model_exclude_none=True,
     response_model_exclude_unset=True,
 )
 @with_dbenv()
 async def get_node_links(
-    node_id: int,
+    uuid: str,
     queries: t.Annotated[QueryParams, Depends(query_params)],
     direction: t.Literal['incoming', 'outgoing'] = Query(
         description='Specify whether to retrieve incoming or outgoing links.',
@@ -299,40 +306,46 @@ async def get_node_links(
 ) -> PaginatedResults[NodeLinks]:
     """Get the incoming or outgoing links of a node.
 
-    :param node_id: The id of the node to retrieve the incoming links for.
+    :param uuid: The uuid of the node to retrieve the incoming links for.
     :param queries: The query parameters, including filters, order_by, page_size, and page.
     :param direction: Specify whether to retrieve incoming or outgoing links.
     :return: The paginated requested linked nodes.
-    :raises HTTPException: 404 if the node with the given id does not exist,
+    :raises HTTPException: 404 if the node with the given uuid does not exist,
         500 for other failures during retrieval.
     """
     try:
-        return repository.get_node_links(node_id, queries, direction=direction)
-    except NotExistent:
-        raise HTTPException(status_code=404, detail=f'Could not find any node with id {node_id}')
-    except Exception as err:
-        raise HTTPException(status_code=500, detail=str(err)) from err
+        return repository.get_node_links(uuid, queries, direction=direction)
+    except NotExistent as exception:
+        raise HTTPException(status_code=404, detail=str(exception)) from exception
+    except Exception as exception:
+        raise HTTPException(status_code=500, detail=str(exception)) from exception
 
 
-@read_router.get('/nodes/{node_id}/download')
+@read_router.get('/nodes/{uuid}/download')
 @with_dbenv()
 async def download_node(
-    node_id: int,
-    download_format: str | None = Query(None, description='Format to download the node in'),
+    uuid: str,
+    download_format: str | None = Query(
+        None,
+        description='Format to download the node in',
+    ),
 ) -> StreamingResponse:
-    """Download AiiDA node by id in a given download format provided as a query parameter.
+    """Download AiiDA node by uuid in a given download format provided as a query parameter.
 
-    :param node_id: The id of the node to retrieve.
+    :param uuid: The uuid of the node to retrieve.
     :param download_format: The format to download the node in.
     :return: StreamingResponse with the exported node content.
     :raises HTTPException: 403 if licensing restrictions prevent export,
-        404 if the node with the given id does not exist,
-        422 if the download format is not specified, or if the download format is not supported.
+        404 if the node with the given uuid does not exist,
+        422 if the download format is not specified, or if the download format is not supported,
+        500 for other failures during retrieval.
     """
     try:
-        node = orm.load_node(node_id)
-    except NotExistent:
-        raise HTTPException(status_code=404, detail=f'Could not find a node with id {node_id}')
+        node = orm.load_node(uuid)
+    except NotExistent as exception:
+        raise HTTPException(status_code=404, detail=str(exception)) from exception
+    except Exception as exception:
+        raise HTTPException(status_code=500, detail=str(exception)) from exception
 
     if download_format is None:
         raise HTTPException(
@@ -347,8 +360,8 @@ async def download_node(
 
         try:
             exported_bytes, _ = node._exportcontent(download_format)
-        except LicensingException as exc:
-            raise HTTPException(status_code=403, detail=str(exc))
+        except LicensingException as exception:
+            raise HTTPException(status_code=403, detail=str(exception)) from exception
 
         def stream() -> t.Generator[bytes, None, None]:
             with io.BytesIO(exported_bytes) as handler:
@@ -398,57 +411,57 @@ MetadataType = t.Union[RepoFileMetadata, RepoDirMetadata]
 
 
 @read_router.get(
-    '/nodes/{node_id}/repo/metadata',
+    '/nodes/{uuid}/repo/metadata',
     response_model=dict[str, MetadataType],
 )
 @with_dbenv()
-async def get_node_repo_file_metadata(node_id: int) -> dict[str, dict]:
+async def get_node_repo_file_metadata(uuid: str) -> dict[str, dict]:
     """Get the repository file metadata of a node.
 
-    :param node_id: The id of the node to retrieve the repository metadata for.
+    :param uuid: The uuid of the node to retrieve the repository metadata for.
     :return: A dictionary with the repository file metadata.
-    :raises HTTPException: 404 if the node with the given id does not exist,
+    :raises HTTPException: 404 if the node with the given uuid does not exist,
         500 for other failures during retrieval.
     """
     try:
-        return repository.get_node_repository_metadata(node_id)
-    except NotExistent:
-        raise HTTPException(status_code=404, detail=f'Could not find any node with id {node_id}')
-    except Exception as err:
-        raise HTTPException(status_code=500, detail=str(err)) from err
+        return repository.get_node_repository_metadata(uuid)
+    except NotExistent as exception:
+        raise HTTPException(status_code=404, detail=str(exception)) from exception
+    except Exception as exception:
+        raise HTTPException(status_code=500, detail=str(exception)) from exception
 
 
-@read_router.get('/nodes/{node_id}/repo/contents')
+@read_router.get('/nodes/{uuid}/repo/contents')
 @with_dbenv()
 async def get_node_repo_file_contents(
-    node_id: int,
-    filename: str | None = Query(None, description='Filename of repository content to retrieve'),
+    uuid: str,
+    filename: str | None = Query(
+        None,
+        description='Filename of repository content to retrieve',
+    ),
 ) -> StreamingResponse:
     """Get the repository contents of a node.
 
-    :param node_id: The id of the node to retrieve the repository contents for.
+    :param uuid: The uuid of the node to retrieve the repository contents for.
     :param filename: The filename of the repository content to retrieve. If None, retrieves all contents.
     :return: StreamingResponse with the requested file content.
-    :raises HTTPException: 404 if the node with the given id does not exist,
+    :raises HTTPException: 404 if the node with the given uuid does not exist,
         404 if the requested file does not exist in the node's repository.
     """
     from urllib.parse import quote
 
     try:
-        node = orm.load_node(node_id)
-    except NotExistent:
-        raise HTTPException(status_code=404, detail=f'Could not find any node with id {node_id}')
+        node = orm.load_node(uuid)
+    except NotExistent as exception:
+        raise HTTPException(status_code=404, detail=str(exception)) from exception
 
     repo = node.base.repository
 
     if filename:
         try:
             file_content = repo.get_object_content(filename, mode='rb')
-        except FileNotFoundError:
-            raise HTTPException(
-                status_code=404,
-                detail=f'Could not find file {filename} in the repository of node with id {node_id}',
-            )
+        except FileNotFoundError as exception:
+            raise HTTPException(status_code=404, detail=str(exception)) from exception
 
         def file_stream() -> t.Generator[bytes, None, None]:
             with io.BytesIO(file_content) as handler:
@@ -467,7 +480,7 @@ async def get_node_repo_file_contents(
             with io.BytesIO(zip_bytes) as handler:
                 yield from handler
 
-        download_name = f'node_{node_id}_repo.zip'
+        download_name = f'node_{uuid}_repo.zip'
         quoted = quote(download_name)
         headers = {'Content-Disposition': f"attachment; filename={download_name!r}; filename*=UTF-8''{quoted}"}
 
@@ -527,8 +540,8 @@ async def create_node_with_files(
     """
     try:
         parameters = t.cast(dict, json.loads(params))
-    except json.JSONDecodeError as exc:
-        raise HTTPException(400, f"Invalid JSON in 'params': {exc}") from exc
+    except json.JSONDecodeError as exception:
+        raise HTTPException(400, str(exception)) from exception
 
     if not (node_type := parameters.get('node_type')):
         raise HTTPException(422, "Missing 'node_type' in params")
@@ -536,10 +549,10 @@ async def create_node_with_files(
     try:
         model_cls = model_registry.get_model(node_type, which='post')
         model = model_cls(**parameters)
-    except KeyError as exc:
-        raise HTTPException(422, str(exc)) from exc
-    except pdt.ValidationError as exc:
-        raise HTTPException(422, f'Validation failed: {exc}') from exc
+    except KeyError as exception:
+        raise HTTPException(422, str(exception)) from exception
+    except pdt.ValidationError as exception:
+        raise HTTPException(422, str(exception)) from exception
 
     files_dict: dict[str, UploadFile] = {}
 
@@ -551,7 +564,7 @@ async def create_node_with_files(
     try:
         return repository.create_entity(model, files=files_dict)
     except json.JSONDecodeError as exception:
-        raise HTTPException(status_code=400, detail=f'Invalid JSON in params: {exception}') from exception
+        raise HTTPException(status_code=400, detail=str(exception)) from exception
     except KeyError as exception:
         raise HTTPException(status_code=422, detail=str(exception)) from exception
     except Exception as exception:

--- a/aiida_restapi/routers/users.py
+++ b/aiida_restapi/routers/users.py
@@ -32,12 +32,15 @@ async def get_users_schema(
 
     :param which: The type of schema to retrieve: 'get' or 'post'.
     :return: A dictionary with 'get' and 'post' keys containing the respective JSON schemas.
-    :raises HTTPException: 422 if the 'which' parameter is not 'get' or 'post'.
+    :raises HTTPException: 422 if the 'which' parameter is not 'get' or 'post',
+        500 for any other failures.
     """
     try:
         return repository.get_entity_schema(which=which)
-    except ValueError as err:
-        raise HTTPException(status_code=422, detail=str(err)) from err
+    except ValueError as exception:
+        raise HTTPException(status_code=422, detail=str(exception)) from exception
+    except Exception as exception:
+        raise HTTPException(status_code=500, detail=str(exception)) from exception
 
 
 @read_router.get('/users/projectable_properties', response_model=list[str])
@@ -68,21 +71,24 @@ async def get_users(
 
 
 @read_router.get(
-    '/users/{user_id}',
+    '/users/{pk}',
     response_model=orm.User.Model,
 )
 @with_dbenv()
-async def get_user(user_id: int) -> orm.User.Model:
-    """Get AiiDA user by id.
+async def get_user(pk: int) -> orm.User.Model:
+    """Get AiiDA user by pk.
 
-    :param user_id: The id of the user to retrieve.
+    :param pk: The pk of the user to retrieve.
     :return: The AiiDA user model.
-    :raises HTTPException: 404 if the user with the given id does not exist,
+    :raises HTTPException: 404 if the user with the given pk does not exist,
+        500 for any other failures.
     """
     try:
-        return repository.get_entity_by_id(user_id)
-    except NotExistent:
-        raise HTTPException(status_code=404, detail=f'Could not find a User with id {user_id}')
+        return repository.get_entity_by_id(pk)
+    except NotExistent as exception:
+        raise HTTPException(status_code=404, detail=str(exception)) from exception
+    except Exception as exception:
+        raise HTTPException(status_code=500, detail=str(exception)) from exception
 
 
 @write_router.post(
@@ -105,5 +111,5 @@ async def create_user(
     """
     try:
         return repository.create_entity(user_model)
-    except Exception as err:
-        raise HTTPException(status_code=500, detail=str(err))
+    except Exception as exception:
+        raise HTTPException(status_code=500, detail=str(exception))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,7 +137,7 @@ def example_processes():
         calc.base.attributes.set('process_label', process_label)
 
         calc.store()
-        calcs.append(calc.pk)
+        calcs.append(calc.uuid)
 
         calc = WorkChainNode()
         calc.set_process_state(state)
@@ -151,7 +151,7 @@ def example_processes():
             calc.pause()
 
         calc.store()
-        calcs.append(calc.pk)
+        calcs.append(calc.uuid)
     return calcs
 
 
@@ -192,7 +192,7 @@ def default_groups():
     test_user_2 = orm.User(email='stravinsky@symphony.org', first_name='Igor', last_name='Stravinsky').store()
     group_1 = orm.Group(label='test_label_1', user=test_user_1).store()
     group_2 = orm.Group(label='test_label_2', user=test_user_2).store()
-    return [group_1.pk, group_2.pk]
+    return [group_1.uuid, group_2.uuid]
 
 
 @pytest.fixture(scope='function')
@@ -203,7 +203,7 @@ def default_nodes():
     node_3 = orm.Str('test_string').store()
     node_4 = orm.Bool(False).store()
 
-    return [node_1.pk, node_2.pk, node_3.pk, node_4.pk]
+    return [node_1.uuid, node_2.uuid, node_3.uuid, node_4.uuid]
 
 
 @pytest.fixture(scope='function')

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -22,7 +22,7 @@ def test_get_groups(client: TestClient):
     assert len(response.json()['results']) == 2
 
 
-def test_get_group(client: TestClient, default_groups: list[int | None]):
+def test_get_group(client: TestClient, default_groups: list[str]):
     """Test retrieving a single group."""
     for group_id in default_groups:
         response = client.get(f'/groups/{group_id}')

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -120,9 +120,9 @@ def test_get_nodes_with_filters(client: TestClient):
     assert results[0]['node_type'] == 'data.core.float.Float.'
 
     # Attributes are excluded, so we need to check separately by id
-    response = client.get(f'/nodes/{results[0]["pk"]}/attributes')
-    assert response.status_code == 200
-    assert response.json()['value'] == 1.1
+    check = client.get(f'/nodes/{results[0]["uuid"]}/attributes')
+    assert check.status_code == 200
+    assert check.json()['value'] == 1.1
 
 
 @pytest.mark.usefixtures('default_nodes')
@@ -153,12 +153,12 @@ def test_get_nodes_pagination(client: TestClient):
     assert all(result['pk'] in (3, 4) for result in results)
 
 
-def test_get_node(client: TestClient, default_nodes: list[int | None]):
+def test_get_node(client: TestClient, default_nodes: list[str | None]):
     """Test retrieving a single nodes."""
-    for nodes_id in default_nodes:
-        response = client.get(f'/nodes/{nodes_id}')
+    for node_id in default_nodes:
+        response = client.get(f'/nodes/{node_id}')
         assert response.status_code == 200, response.content
-        assert response.json()['pk'] == nodes_id
+        assert response.json()['uuid'] == node_id
 
 
 def test_get_download_formats(client: TestClient):
@@ -200,7 +200,7 @@ def test_get_download_formats(client: TestClient):
 
 def test_get_node_repository_metadata(client: TestClient, array_data_node: orm.ArrayData):
     """Test retrieving repository metadata for a node."""
-    response = client.get(f'/nodes/{array_data_node.pk}/repo/metadata')
+    response = client.get(f'/nodes/{array_data_node.uuid}/repo/metadata')
     assert response.status_code == 200
     result = response.json()
     default = orm.ArrayData.default_array_name + '.npy'
@@ -410,7 +410,7 @@ def test_create_single_file(client: TestClient):
     response = client.post('/nodes/file-upload', files=files, data=data)
     assert response.status_code == 200, response.json()
 
-    check = client.get(f'/nodes/{response.json()["pk"]}/repo/metadata')
+    check = client.get(f'/nodes/{response.json()["uuid"]}/repo/metadata')
     assert check.status_code == 200, check.content
     result = check.json()
     assert 'test_file.txt' in result
@@ -444,7 +444,7 @@ def test_create_single_file_binary(client: TestClient):
     response = client.post('/nodes/file-upload', files=files, data=data)
     assert response.status_code == 200, response.json()
 
-    check = client.get(f'/nodes/{response.json()["pk"]}/repo/metadata')
+    check = client.get(f'/nodes/{response.json()["uuid"]}/repo/metadata')
     assert check.status_code == 200, check.content
     result = check.json()
     assert 'binary_file.bin' in result
@@ -485,7 +485,7 @@ def test_create_folder_data(client: TestClient):
     response = client.post('/nodes/file-upload', files=files, data=data)
     assert response.status_code == 200, response.json()
 
-    check = client.get(f'/nodes/{response.json()["pk"]}/repo/metadata')
+    check = client.get(f'/nodes/{response.json()["uuid"]}/repo/metadata')
     assert check.status_code == 200, check.content
     result = check.json()
     assert 'folder' in result
@@ -535,7 +535,7 @@ def test_create_node_with_files_has_zipped_metadata(client: TestClient):
     response = client.post('/nodes/file-upload', files=files, data=data)
     assert response.status_code == 200, response.json()
 
-    check = client.get(f'/nodes/{response.json()["pk"]}/repo/metadata')
+    check = client.get(f'/nodes/{response.json()["uuid"]}/repo/metadata')
     assert check.status_code == 200, check.content
     result = check.json()
     assert 'zipped' in result
@@ -593,7 +593,7 @@ def test_create_additional_attribute(client: TestClient):
     )
     assert response.status_code == 200, response.content
 
-    check = client.get(f'/nodes/{response.json()["pk"]}/attributes')
+    check = client.get(f'/nodes/{response.json()["uuid"]}/attributes')
     assert check.status_code == 200, check.content
     result = check.json()
     assert 'value' in result
@@ -614,7 +614,7 @@ def test_create_bool_with_extra(client: TestClient):
     assert response.status_code == 200, response.content
 
     # We exclude extras from the node response, so we check by retrieving them separately
-    check = client.get(f'/nodes/{response.json()["pk"]}/extras')
+    check = client.get(f'/nodes/{response.json()["uuid"]}/extras')
     assert check.status_code == 200, check.content
     result = check.json()
     assert result['extra_one'] == 'value_1'

--- a/tests/test_querybuilder.py
+++ b/tests/test_querybuilder.py
@@ -57,7 +57,7 @@ def test_querybuilder_numeric_flat(client: TestClient):
     assert data['results'] == [1, 1.1]
 
 
-def test_querybuilder_integer_in_group(client: TestClient, default_nodes, default_groups):
+def test_querybuilder_integer_in_group(client: TestClient, default_nodes: list[str], default_groups: list[str]):
     """Test a QueryBuilder request filtering integers by group membership."""
     node = orm.load_node(default_nodes[0])
     group = orm.load_group(default_groups[0])

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,5 +1,7 @@
 """Test the /users endpoint"""
 
+from __future__ import annotations
+
 import pytest
 from aiida import orm
 from fastapi.testclient import TestClient
@@ -25,7 +27,7 @@ def test_get_users(client: TestClient):
     assert len(response.json()['results']) == 2 + 1
 
 
-def test_get_user(client: TestClient, default_users):
+def test_get_user(client: TestClient, default_users: list[int | None]):
     """Test retrieving a single user."""
     for user_id in default_users:
         response = client.get(f'/users/{user_id}')


### PR DESCRIPTION
This PR switches to using entity UUIDs for `get_entity_by_id` endpoints. This does not apply to users, which don't have a UUID, and computers (for some reason). For now, these use PKs (as was done in the old RESTAPI).

### Peripheral change warning!!!
I also in this PR make error handling a bit more uniform across endpoints. However, I'm wondering if guarding against general `Exception` errors, raising code 500 (internal errors), is wise. I'm thinking we should allow these errors through, so that we can later guard against the actual specific errors. These are hard to see when all you get is the single-line error message (no traceback). But then the traceback may be to frighting for the client. Anyhow, keeping them in for now. @eimrek good to get your thoughts on this.