### PR TITLE
Add prefixes at the router layer

### DIFF
--- a/aiida_restapi/routers/auth.py
+++ b/aiida_restapi/routers/auth.py
@@ -33,10 +33,10 @@ class UserInDB(orm.User.Model):
 
 pwd_context = PasswordHasher()
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl='token')
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl=f'{config.API_CONFIG["PREFIX"]}/auth/token')
 
-read_router = APIRouter()
-write_router = APIRouter()
+read_router = APIRouter(prefix='/auth')
+write_router = APIRouter(prefix='/auth')
 
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
@@ -114,7 +114,10 @@ async def get_current_active_user(
     return current_user
 
 
-@write_router.post('/token', response_model=Token)
+@write_router.post(
+    '/token',
+    response_model=Token,
+)
 async def login_for_access_token(
     form_data: OAuth2PasswordRequestForm = Depends(),
 ) -> dict[str, t.Any]:
@@ -131,7 +134,10 @@ async def login_for_access_token(
     return {'access_token': access_token, 'token_type': 'bearer'}
 
 
-@read_router.get('/auth/me/', response_model=orm.User.Model)
+@read_router.get(
+    '/me/',
+    response_model=orm.User.Model,
+)
 async def read_users_me(
     current_user: t.Annotated[orm.User.Model, Depends(get_current_active_user)],
 ) -> orm.User.Model:

--- a/aiida_restapi/routers/computers.py
+++ b/aiida_restapi/routers/computers.py
@@ -15,13 +15,16 @@ from aiida_restapi.repository.entity import EntityRepository
 
 from .auth import UserInDB, get_current_active_user
 
-read_router = APIRouter()
-write_router = APIRouter()
+read_router = APIRouter(prefix='/computers')
+write_router = APIRouter(prefix='/computers')
 
 repository = EntityRepository[orm.Computer, orm.Computer.Model](orm.Computer)
 
 
-@read_router.get('/computers/schema')
+@read_router.get(
+    '/schema',
+    response_model=dict,
+)
 async def get_computers_schema(
     which: t.Literal['get', 'post'] = Query(
         'get',
@@ -43,7 +46,10 @@ async def get_computers_schema(
         raise HTTPException(status_code=500, detail=str(exception)) from exception
 
 
-@read_router.get('/computers/projectable_properties', response_model=list[str])
+@read_router.get(
+    '/projectable_properties',
+    response_model=list[str],
+)
 async def get_computer_projectable_properties() -> list[str]:
     """Get projectable properties for AiiDA computers.
 
@@ -53,7 +59,7 @@ async def get_computer_projectable_properties() -> list[str]:
 
 
 @read_router.get(
-    '/computers',
+    '',
     response_model=PaginatedResults[orm.Computer.Model],
     response_model_exclude_none=True,
     response_model_exclude_unset=True,
@@ -71,7 +77,7 @@ async def get_computers(
 
 
 @read_router.get(
-    '/computers/{pk}',
+    '/{pk}',
     response_model=orm.Computer.Model,
     response_model_exclude_none=True,
     response_model_exclude_unset=True,
@@ -93,7 +99,10 @@ async def get_computer(pk: str) -> orm.Computer.Model:
         raise HTTPException(status_code=500, detail=str(exception)) from exception
 
 
-@read_router.get('/computers/{pk}/metadata', response_model=dict[str, t.Any])
+@read_router.get(
+    '/{pk}/metadata',
+    response_model=dict[str, t.Any],
+)
 @with_dbenv()
 async def get_computer_metadata(pk: str) -> dict[str, t.Any]:
     """Get metadata of an AiiDA computer by pk.
@@ -113,7 +122,7 @@ async def get_computer_metadata(pk: str) -> dict[str, t.Any]:
 
 
 @write_router.post(
-    '/computers',
+    '',
     response_model=orm.Computer.Model,
     response_model_exclude_none=True,
     response_model_exclude_unset=True,

--- a/aiida_restapi/routers/daemon.py
+++ b/aiida_restapi/routers/daemon.py
@@ -11,8 +11,8 @@ from pydantic import BaseModel, Field
 
 from .auth import UserInDB, get_current_active_user
 
-read_router = APIRouter()
-write_router = APIRouter()
+read_router = APIRouter(prefix='/daemon')
+write_router = APIRouter(prefix='/daemon')
 
 
 class DaemonStatusModel(BaseModel):
@@ -23,7 +23,7 @@ class DaemonStatusModel(BaseModel):
 
 
 @read_router.get(
-    '/daemon/status',
+    '/status',
     response_model=DaemonStatusModel,
 )
 @with_dbenv()
@@ -46,7 +46,7 @@ async def get_daemon_status() -> DaemonStatusModel:
 
 
 @write_router.post(
-    '/daemon/start',
+    '/start',
     response_model=DaemonStatusModel,
 )
 @with_dbenv()
@@ -73,7 +73,7 @@ async def get_daemon_start(
 
 
 @write_router.post(
-    '/daemon/stop',
+    '/stop',
     response_model=DaemonStatusModel,
 )
 @with_dbenv()

--- a/aiida_restapi/routers/groups.py
+++ b/aiida_restapi/routers/groups.py
@@ -15,13 +15,16 @@ from aiida_restapi.repository.entity import EntityRepository
 
 from .auth import UserInDB, get_current_active_user
 
-read_router = APIRouter()
-write_router = APIRouter()
+read_router = APIRouter(prefix='/groups')
+write_router = APIRouter(prefix='/groups')
 
 repository = EntityRepository[orm.Group, orm.Group.Model](orm.Group)
 
 
-@read_router.get('/groups/schema')
+@read_router.get(
+    '/schema',
+    response_model=dict,
+)
 async def get_groups_schema(
     which: t.Literal['get', 'post'] = Query(
         'get',
@@ -43,7 +46,10 @@ async def get_groups_schema(
         raise HTTPException(status_code=500, detail=str(exception)) from exception
 
 
-@read_router.get('/groups/projectable_properties', response_model=list[str])
+@read_router.get(
+    '/projectable_properties',
+    response_model=list[str],
+)
 async def get_group_projectable_properties() -> list[str]:
     """Get projectable properties for AiiDA groups.
 
@@ -53,7 +59,7 @@ async def get_group_projectable_properties() -> list[str]:
 
 
 @read_router.get(
-    '/groups',
+    '',
     response_model=PaginatedResults[orm.Group.Model],
     response_model_exclude_none=True,
     response_model_exclude_unset=True,
@@ -71,7 +77,7 @@ async def get_groups(
 
 
 @read_router.get(
-    '/groups/{uuid}',
+    '/{uuid}',
     response_model=orm.Group.Model,
     response_model_exclude_none=True,
     response_model_exclude_unset=True,
@@ -94,7 +100,7 @@ async def get_group(uuid: str) -> orm.Group.Model:
 
 
 @read_router.get(
-    '/groups/{uuid}/extras',
+    '/{uuid}/extras',
     response_model=dict[str, t.Any],
 )
 @with_dbenv()
@@ -115,7 +121,7 @@ async def get_group_extras(uuid: str) -> dict[str, t.Any]:
 
 
 @write_router.post(
-    '/groups',
+    '',
     response_model=orm.Group.Model,
     response_model_exclude_none=True,
     response_model_exclude_unset=True,

--- a/aiida_restapi/routers/nodes.py
+++ b/aiida_restapi/routers/nodes.py
@@ -22,8 +22,8 @@ from aiida_restapi.repository.node import NodeLinks, NodeRepository
 
 from .auth import UserInDB, get_current_active_user
 
-read_router = APIRouter()
-write_router = APIRouter()
+read_router = APIRouter(prefix='/nodes')
+write_router = APIRouter(prefix='/nodes')
 
 repository = NodeRepository[orm.Node, orm.Node.Model](orm.Node)
 
@@ -37,7 +37,10 @@ else:
     NodeModelUnion = model_registry.ModelUnion
 
 
-@read_router.get('/nodes/schema')
+@read_router.get(
+    '/schema',
+    response_model=dict,
+)
 async def get_nodes_schema(
     node_type: str | None = Query(
         None,
@@ -69,7 +72,10 @@ async def get_nodes_schema(
         raise HTTPException(status_code=500, detail=str(exception)) from exception
 
 
-@read_router.get('/nodes/projectable_properties')
+@read_router.get(
+    '/projectable_properties',
+    response_model=list[str],
+)
 @with_dbenv()
 async def get_node_projectable_properties(
     node_type: str | None = Query(
@@ -120,7 +126,10 @@ class NodeStatistics(pdt.BaseModel):
     )
 
 
-@read_router.get('/nodes/statistics', response_model=NodeStatistics)
+@read_router.get(
+    '/statistics',
+    response_model=NodeStatistics,
+)
 @with_dbenv()
 async def get_nodes_statistics(user: int | None = None) -> dict[str, t.Any]:
     """Get node statistics.
@@ -149,7 +158,7 @@ async def get_nodes_statistics(user: int | None = None) -> dict[str, t.Any]:
     return backend.query().get_creation_statistics(user_pk=user)
 
 
-@read_router.get('/nodes/download_formats')
+@read_router.get('/download_formats')
 async def get_nodes_download_formats() -> dict[str, t.Any]:
     """Get download formats for AiiDA nodes.
 
@@ -166,7 +175,7 @@ async def get_nodes_download_formats() -> dict[str, t.Any]:
 
 
 @read_router.get(
-    '/nodes',
+    '',
     response_model=PaginatedResults[orm.Node.Model],
     response_model_exclude_none=True,
     response_model_exclude_unset=True,
@@ -193,7 +202,10 @@ class NodeType(pdt.BaseModel):
     node_schema: str = pdt.Field(description='The URL to access the schema of this node type.')
 
 
-@read_router.get('/nodes/types', response_model=list[NodeType])
+@read_router.get(
+    '/types',
+    response_model=list[NodeType],
+)
 async def get_node_types() -> list:
     """Get all node types in machine-actionable format.
 
@@ -203,9 +215,9 @@ async def get_node_types() -> list:
     >>>   {
     >>>     "label": "Int",
     >>>     "node_type": "data.core.int.Int.",
-    >>>     "nodes": "/nodes?filters={\"node_type\":{\"data.core.int.Int.\"}}",
-    >>>     "projections": "/nodes/projectable_properties?type=data.core.int.Int.",
-    >>>     "node_schema": "/nodes/schema?type=data.core.int.Int.",
+    >>>     "nodes": ".../nodes?filters={\"node_type\":{\"data.core.int.Int.\"}}",
+    >>>     "projections": ".../nodes/projectable_properties?type=data.core.int.Int.",
+    >>>     "node_schema": ".../nodes/schema?type=data.core.int.Int.",
     >>>   },
     >>>   ...
     >>> ]
@@ -226,7 +238,7 @@ async def get_node_types() -> list:
 
 
 @read_router.get(
-    '/nodes/{uuid}',
+    '/{uuid}',
     response_model=orm.Node.Model,
     response_model_exclude_none=True,
     response_model_exclude_unset=True,
@@ -249,7 +261,7 @@ async def get_node(uuid: str) -> orm.Node.Model:
 
 
 @read_router.get(
-    '/nodes/{uuid}/attributes',
+    '/{uuid}/attributes',
     response_model=dict[str, t.Any],
 )
 @with_dbenv()
@@ -270,7 +282,7 @@ async def get_node_attributes(uuid: str) -> dict[str, t.Any]:
 
 
 @read_router.get(
-    '/nodes/{uuid}/extras',
+    '/{uuid}/extras',
     response_model=dict[str, t.Any],
 )
 @with_dbenv()
@@ -291,7 +303,7 @@ async def get_node_extras(uuid: str) -> dict[str, t.Any]:
 
 
 @read_router.get(
-    '/nodes/{uuid}/links',
+    '/{uuid}/links',
     response_model=PaginatedResults[NodeLinks],
     response_model_exclude_none=True,
     response_model_exclude_unset=True,
@@ -321,7 +333,10 @@ async def get_node_links(
         raise HTTPException(status_code=500, detail=str(exception)) from exception
 
 
-@read_router.get('/nodes/{uuid}/download')
+@read_router.get(
+    '/{uuid}/download',
+    response_class=StreamingResponse,
+)
 @with_dbenv()
 async def download_node(
     uuid: str,
@@ -411,7 +426,7 @@ MetadataType = t.Union[RepoFileMetadata, RepoDirMetadata]
 
 
 @read_router.get(
-    '/nodes/{uuid}/repo/metadata',
+    '/{uuid}/repo/metadata',
     response_model=dict[str, MetadataType],
 )
 @with_dbenv()
@@ -431,7 +446,10 @@ async def get_node_repo_file_metadata(uuid: str) -> dict[str, dict]:
         raise HTTPException(status_code=500, detail=str(exception)) from exception
 
 
-@read_router.get('/nodes/{uuid}/repo/contents')
+@read_router.get(
+    '/{uuid}/repo/contents',
+    response_class=StreamingResponse,
+)
 @with_dbenv()
 async def get_node_repo_file_contents(
     uuid: str,
@@ -488,7 +506,7 @@ async def get_node_repo_file_contents(
 
 
 @write_router.post(
-    '/nodes',
+    '',
     response_model=orm.Node.Model,
     response_model_exclude_none=True,
     response_model_exclude_unset=True,
@@ -515,7 +533,7 @@ async def create_node(
 
 
 @write_router.post(
-    '/nodes/file-upload',
+    '/file-upload',
     response_model=orm.Node.Model,
     response_model_exclude_none=True,
     response_model_exclude_unset=True,

--- a/aiida_restapi/routers/querybuilder.py
+++ b/aiida_restapi/routers/querybuilder.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, HTTPException, Query
 
 from aiida_restapi.common.pagination import PaginatedResults
 
-read_router = APIRouter()
+read_router = APIRouter(prefix='/querybuilder')
 
 
 class QueryBuilderPathItem(pdt.BaseModel):
@@ -110,7 +110,7 @@ class QueryBuilderDict(pdt.BaseModel):
 
 
 @read_router.post(
-    '/querybuilder',
+    '',
     response_model=PaginatedResults,
     response_model_exclude_none=True,
     response_model_exclude_unset=True,

--- a/aiida_restapi/routers/server.py
+++ b/aiida_restapi/routers/server.py
@@ -13,7 +13,7 @@ from starlette.routing import Route
 
 from aiida_restapi.config import API_CONFIG
 
-read_router = APIRouter()
+read_router = APIRouter(prefix='/server')
 
 
 class ServerInfo(pdt.BaseModel):
@@ -27,7 +27,7 @@ class ServerInfo(pdt.BaseModel):
 
 
 @read_router.get(
-    '/server/info',
+    '/info',
     response_model=ServerInfo,
 )
 async def get_server_info() -> dict[str, str]:
@@ -52,7 +52,7 @@ class ServerEndpoint(pdt.BaseModel):
 
 
 @read_router.get(
-    '/server/endpoints',
+    '/endpoints',
     response_model=dict[str, list[ServerEndpoint]],
 )
 async def get_server_endpoints(request: Request) -> dict[str, list[dict]]:
@@ -83,7 +83,7 @@ async def get_server_endpoints(request: Request) -> dict[str, list[dict]]:
 
 
 @read_router.get(
-    '/server/endpoints/table',
+    '/endpoints/table',
     name='endpoints',
     response_class=HTMLResponse,
 )

--- a/aiida_restapi/routers/submit.py
+++ b/aiida_restapi/routers/submit.py
@@ -13,7 +13,7 @@ from fastapi import APIRouter, Depends, HTTPException
 
 from .auth import UserInDB, get_current_active_user
 
-write_router = APIRouter()
+write_router = APIRouter(prefix='/submit')
 
 
 def process_inputs(inputs: dict[str, t.Any]) -> dict[str, t.Any]:
@@ -59,7 +59,7 @@ class ProcessSubmitModel(pdt.BaseModel):
 
 
 @write_router.post(
-    '/submit',
+    '',
     response_model=orm.Node.Model,
     response_model_exclude_none=True,
     response_model_exclude_unset=True,

--- a/aiida_restapi/routers/users.py
+++ b/aiida_restapi/routers/users.py
@@ -15,13 +15,16 @@ from aiida_restapi.repository.entity import EntityRepository
 
 from .auth import UserInDB, get_current_active_user
 
-read_router = APIRouter()
-write_router = APIRouter()
+read_router = APIRouter(prefix='/users')
+write_router = APIRouter(prefix='/users')
 
 repository = EntityRepository[orm.User, orm.User.Model](orm.User)
 
 
-@read_router.get('/users/schema')
+@read_router.get(
+    '/schema',
+    response_model=dict,
+)
 async def get_users_schema(
     which: t.Literal['get', 'post'] = Query(
         'get',
@@ -43,7 +46,10 @@ async def get_users_schema(
         raise HTTPException(status_code=500, detail=str(exception)) from exception
 
 
-@read_router.get('/users/projectable_properties', response_model=list[str])
+@read_router.get(
+    '/projectable_properties',
+    response_model=list[str],
+)
 async def get_user_projectable_properties() -> list[str]:
     """Get projectable properties for AiiDA user.
 
@@ -53,7 +59,7 @@ async def get_user_projectable_properties() -> list[str]:
 
 
 @read_router.get(
-    '/users',
+    '',
     response_model=PaginatedResults[orm.User.Model],
     response_model_exclude_none=True,
     response_model_exclude_unset=True,
@@ -71,7 +77,7 @@ async def get_users(
 
 
 @read_router.get(
-    '/users/{pk}',
+    '/{pk}',
     response_model=orm.User.Model,
 )
 @with_dbenv()
@@ -92,7 +98,7 @@ async def get_user(pk: int) -> orm.User.Model:
 
 
 @write_router.post(
-    '/users',
+    '',
     response_model=orm.User.Model,
     response_model_exclude_none=True,
     response_model_exclude_unset=True,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -6,7 +6,7 @@ from fastapi.testclient import TestClient
 def test_authenticate_user(client: TestClient):
     """Test authenticating as a user."""
     # authenticate with username and password
-    response = client.post('/token', data={'username': 'johndoe@example.com', 'password': 'secret'})
+    response = client.post('/auth/token', data={'username': 'johndoe@example.com', 'password': 'secret'})
     assert response.status_code == 200, response.content
     token = response.json()['access_token']
 


### PR DESCRIPTION
This PR is adds a prefix to the `APIRouter` instances to avoid having to specify them at each module route. 