### PR TITLE
Rename repository modules

### DIFF
--- a/aiida_restapi/main.py
+++ b/aiida_restapi/main.py
@@ -11,7 +11,11 @@ from aiida_restapi.routers import auth, computers, daemon, groups, nodes, queryb
 
 
 def create_app() -> FastAPI:
-    """Create the FastAPI application and include the routers."""
+    """Create the FastAPI application and include the routers.
+
+    :return: The FastAPI application.
+    :rtype: FastAPI
+    """
 
     read_only = os.getenv('AIIDA_RESTAPI_READ_ONLY') == '1'
 

--- a/aiida_restapi/models/node.py
+++ b/aiida_restapi/models/node.py
@@ -1,5 +1,3 @@
-"""REST API models for ORM nodes."""
-
 from __future__ import annotations
 
 import typing as t
@@ -8,6 +6,80 @@ import pydantic as pdt
 from aiida.orm import Node
 from aiida.plugins import get_entry_points
 from importlib_metadata import EntryPoint
+
+
+class NodeStatistics(pdt.BaseModel):
+    """Pydantic model representing node statistics."""
+
+    total: int = pdt.Field(
+        description='Total number of nodes.',
+        examples=[47],
+    )
+    types: dict[str, int] = pdt.Field(
+        description='Number of nodes by type.',
+        examples=[
+            {
+                'data.core.int.Int.': 42,
+                'data.core.singlefile.SinglefileData.': 5,
+            }
+        ],
+    )
+    ctime_by_day: dict[str, int] = pdt.Field(
+        description='Number of nodes created per day (YYYY-MM-DD).',
+        examples=[
+            {
+                '2012-01-01': 10,
+                '2012-01-02': 15,
+            }
+        ],
+    )
+
+
+class NodeType(pdt.BaseModel):
+    """Pydantic model representing a node type."""
+
+    label: str = pdt.Field(description='The class name of the node type.')
+    node_type: str = pdt.Field(description='The AiiDA node type string.')
+    nodes: str = pdt.Field(description='The URL to access nodes of this type.')
+    projections: str = pdt.Field(description='The URL to access projectable properties of this node type.')
+    node_schema: str = pdt.Field(description='The URL to access the schema of this node type.')
+
+
+class RepoFileMetadata(pdt.BaseModel):
+    """Pydantic model representing the metadata of a file in the AiiDA repository."""
+
+    type: t.Literal['FILE'] = pdt.Field(
+        description='The type of the repository object.',
+    )
+    binary: bool = pdt.Field(
+        False,
+        description='Whether the file is binary.',
+    )
+    size: int = pdt.Field(
+        description='The size of the file in bytes.',
+    )
+    download: str = pdt.Field(
+        description='The URL to download the file.',
+    )
+
+
+class RepoDirMetadata(pdt.BaseModel):
+    """Pydantic model representing the metadata of a directory in the AiiDA repository."""
+
+    type: t.Literal['DIRECTORY'] = pdt.Field(
+        description='The type of the repository object.',
+    )
+    objects: dict[str, t.Union[RepoFileMetadata, 'RepoDirMetadata']] = pdt.Field(
+        description='A dictionary with the metadata of the objects in the directory.',
+    )
+
+
+MetadataType = t.Union[RepoFileMetadata, RepoDirMetadata]
+
+
+class NodeLink(Node.Model):
+    link_label: str = pdt.Field(description='The label of the link to the node.')
+    link_type: str = pdt.Field(description='The type of the link to the node.')
 
 
 class NodeModelRegistry:

--- a/aiida_restapi/models/node/__init__.py
+++ b/aiida_restapi/models/node/__init__.py
@@ -1,7 +1,0 @@
-from .models import NodeLinks
-from .registry import NodeModelRegistry
-
-__all__ = [
-    'NodeLinks',
-    'NodeModelRegistry',
-]

--- a/aiida_restapi/models/node/models.py
+++ b/aiida_restapi/models/node/models.py
@@ -1,7 +1,0 @@
-import pydantic as pdt
-from aiida.orm import Node
-
-
-class NodeLinks(Node.Model):
-    link_label: str = pdt.Field(description='The label of the link to the node.')
-    link_type: str = pdt.Field(description='The type of the link to the node.')

--- a/aiida_restapi/routers/users.py
+++ b/aiida_restapi/routers/users.py
@@ -11,14 +11,14 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 
 from aiida_restapi.common.pagination import PaginatedResults
 from aiida_restapi.common.query import QueryParams, query_params
-from aiida_restapi.repository.entity import EntityRepository
+from aiida_restapi.services.entity import EntityService
 
 from .auth import UserInDB, get_current_active_user
 
 read_router = APIRouter(prefix='/users')
 write_router = APIRouter(prefix='/users')
 
-repository = EntityRepository[orm.User, orm.User.Model](orm.User)
+service = EntityService[orm.User, orm.User.Model](orm.User)
 
 
 @read_router.get(
@@ -39,7 +39,7 @@ async def get_users_schema(
         500 for any other failures.
     """
     try:
-        return repository.get_entity_schema(which=which)
+        return service.get_schema(which=which)
     except ValueError as exception:
         raise HTTPException(status_code=422, detail=str(exception)) from exception
     except Exception as exception:
@@ -47,15 +47,15 @@ async def get_users_schema(
 
 
 @read_router.get(
-    '/projectable_properties',
+    '/projections',
     response_model=list[str],
 )
-async def get_user_projectable_properties() -> list[str]:
-    """Get projectable properties for AiiDA user.
+async def get_user_projections() -> list[str]:
+    """Get queryable projections for AiiDA users.
 
-    :return: The list of projectable properties for AiiDA user.
+    :return: The list of queryable projections for AiiDA users.
     """
-    return repository.get_projectable_properties()
+    return service.get_projections()
 
 
 @read_router.get(
@@ -73,7 +73,7 @@ async def get_users(
     :param queries: The query parameters, including filters, order_by, page_size, and page.
     :return: The paginated results, including total count, current page, page size, and list of user models.
     """
-    return repository.get_entities(queries)
+    return service.get_many(queries)
 
 
 @read_router.get(
@@ -90,7 +90,7 @@ async def get_user(pk: int) -> orm.User.Model:
         500 for any other failures.
     """
     try:
-        return repository.get_entity_by_id(pk)
+        return service.get_one(pk)
     except NotExistent as exception:
         raise HTTPException(status_code=404, detail=str(exception)) from exception
     except Exception as exception:
@@ -116,6 +116,6 @@ async def create_user(
     :raises HTTPException: 500 for any failures during user creation.
     """
     try:
-        return repository.create_entity(user_model)
+        return service.add_one(user_model)
     except Exception as exception:
         raise HTTPException(status_code=500, detail=str(exception))

--- a/aiida_restapi/services/entity.py
+++ b/aiida_restapi/services/entity.py
@@ -9,22 +9,24 @@ from aiida_restapi.common.query import QueryParams
 from aiida_restapi.common.types import EntityModelType, EntityType
 
 
-class EntityRepository(t.Generic[EntityType, EntityModelType]):
+class EntityService(t.Generic[EntityType, EntityModelType]):
     """Utility class for AiiDA REST API operations.
 
     This class provides methods to retrieve AiiDA entities with optional filtering, sorting, and pagination.
 
-    :ivar entity_cls: The AiiDA ORM entity class associated with this utility, e.g. `orm.User`, `orm.Node`, etc.
+    :param entity_class: The AiiDA ORM entity class associated with this utility, e.g. `orm.User`, `orm.Node`, etc.
     """
 
     def __init__(self, entity_class: type[EntityType]) -> None:
         self.entity_class = entity_class
 
-    def get_entity_schema(self, which: t.Literal['get', 'post'] | None = None) -> dict:
+    def get_schema(self, which: t.Literal['get', 'post'] | None = None) -> dict:
         """Get JSON schema for the AiiDA entity.
 
         :param which: The type of schema to retrieve: 'get' or 'post'.
+        :type which: str | None
         :return: A dictionary with 'get' and 'post' keys containing the respective JSON schemas.
+        :rtype: dict
         :raises ValueError: If the 'which' parameter is not 'get' or 'post'.
         """
         if not which:
@@ -38,18 +40,21 @@ class EntityRepository(t.Generic[EntityType, EntityModelType]):
             return self.entity_class.CreateModel.model_json_schema()
         raise ValueError(f'Schema type "{which}" not supported; expected "get" or "post"')
 
-    def get_projectable_properties(self) -> list[str]:
-        """Get projectable properties for the AiiDA entity.
+    def get_projections(self) -> list[str]:
+        """Get queryable projections for the AiiDA entity.
 
-        :return: The list of projectable properties for the AiiDA entity.
+        :return: The list of queryable projections for the AiiDA entity.
+        :rtype: list[str]
         """
         return self.entity_class.fields.keys()
 
-    def get_entities(self, queries: QueryParams) -> PaginatedResults[EntityModelType]:
+    def get_many(self, queries: QueryParams) -> PaginatedResults[EntityModelType]:
         """Get AiiDA entities with optional filtering, sorting, and/or pagination.
 
         :param queries: The query parameters, including filters, order_by, page_size, and page.
+        :type queries: QueryParams
         :return: The paginated results, including total count, current page, page size, and list of entity models.
+        :rtype: PaginatedResults[EntityModelType]
         """
         total = self.entity_class.collection.count(filters=queries.filters)
         results = self.entity_class.collection.find(
@@ -62,45 +67,52 @@ class EntityRepository(t.Generic[EntityType, EntityModelType]):
             total=total,
             page=queries.page,
             page_size=queries.page_size,
-            results=[self.to_model(result) for result in results],
+            results=[self._to_model(result) for result in results],
         )
 
-    def get_entity_by_id(self, identifier: str | int) -> EntityModelType:
+    def get_one(self, identifier: str | int) -> EntityModelType:
         """Get an AiiDA entity by id.
 
         :param identifier: The id of the entity to retrieve.
+        :type identifier: str | int
         :return: The AiiDA entity model, e.g. `orm.User.Model`, `orm.Node.Model`, etc.
+        :rtype: EntityModelType
         """
         entity = self.entity_class.collection.get(**{self.entity_class.identity_field: identifier})
-        return self.to_model(entity)
+        return self._to_model(entity)
 
-    def get_entity_extras(self, identifier: str | int) -> dict[str, t.Any]:
-        """Get the extras of an entity.
+    def get_field(self, identifier: str | int, field: str) -> t.Any:
+        """Get a specific field of an entity.
 
         :param identifier: The id of the entity to retrieve the extras for.
-        :return: A dictionary with the entity extras.
+        :type identifier: str | int
+        :param field: The specific field to retrieve.
+        :type field: str
+        :return: The value of the specified field.
+        :rtype: t.Any
         """
-        return t.cast(
-            dict,
-            self.entity_class.collection.query(
-                filters={self.entity_class.identity_field: identifier},
-                project=['extras'],
-            ).first()[0],
-        )
+        return self.entity_class.collection.query(
+            filters={self.entity_class.identity_field: identifier},
+            project=[field],
+        ).first()[0]
 
-    def create_entity(self, model: EntityModelType) -> EntityModelType:
+    def add_one(self, model: EntityModelType) -> EntityModelType:
         """Create new AiiDA entity from its model.
 
         :param model: The Pydantic model of the entity to create.
+        :type model: EntityModelType
         :return: The created and stored AiiDA `Entity` instance.
+        :rtype: EntityModelType
         """
         entity = self.entity_class.from_model(model).store()
-        return self.to_model(entity)
+        return self._to_model(entity)
 
-    def to_model(self, entity: EntityType) -> EntityModelType:
+    def _to_model(self, entity: EntityType) -> EntityModelType:
         """Convert an AiiDA entity to its Pydantic model.
 
         :param entity: The AiiDA entity to convert.
+        :type entity: EntityType
         :return: The Pydantic model of the entity, excluding any fields specified in `excluded_fields`.
+        :rtype: EntityModelType
         """
         return t.cast(EntityModelType, entity.to_model(minimal=True))

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -89,6 +89,7 @@ nitpick_ignore = [
             'aiida_restapi.aiida_db_mappings.Config',
             'aiida_restapi.models.Config',
             'aiida_restapi.routers.auth.Config',
+            'aiida_restapi.routers.nodes.NodeType',
             'aiida_restapi.graphql.orm_factories.AiidaOrmObjectType',
             'aiida_restapi.graphql.nodes.LinkObjectType',
             'aiida_restapi.graphql.orm_factories.multirow_cls_factory.<locals>.AiidaOrmRowsType',

--- a/tests/test_computers.py
+++ b/tests/test_computers.py
@@ -9,7 +9,7 @@ from fastapi.testclient import TestClient
 
 def test_get_computer_projectable_properties(client: TestClient):
     """Test get projectable properties for computer."""
-    response = client.get('/computers/projectable_properties')
+    response = client.get('/computers/projections')
     assert response.status_code == 200
     assert response.json() == sorted(orm.Computer.fields.keys())
 

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -9,7 +9,7 @@ from fastapi.testclient import TestClient
 
 def test_get_group_projectable_properties(client: TestClient):
     """Test get projectable properties for group."""
-    response = client.get('/groups/projectable_properties')
+    response = client.get('/groups/projections')
     assert response.status_code == 200
     assert response.json() == sorted(orm.Group.fields.keys())
 

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -17,14 +17,14 @@ if t.TYPE_CHECKING:
 
 def test_get_node_projectable_properties(client: TestClient):
     """Test get projectable properties for nodes."""
-    response = client.get('/nodes/projectable_properties')
+    response = client.get('/nodes/projections')
     assert response.status_code == 200
     assert response.json() == sorted(orm.Node.fields.keys())
 
 
 def test_get_node_projectable_properties_by_type(client: TestClient):
     """Test get projectable properties for nodes by valid type."""
-    response = client.get('/nodes/projectable_properties?type=data.core.int.Int.')
+    response = client.get('/nodes/projections?type=data.core.int.Int.')
     assert response.status_code == 200
     result = response.json()
     assert result == sorted(orm.Int.fields.keys())
@@ -34,7 +34,7 @@ def test_get_node_projectable_properties_by_type(client: TestClient):
 
 def test_get_node_projectable_properties_by_invalid_type(client: TestClient):
     """Test get projectable properties for nodes with invalid type."""
-    response = client.get('/nodes/projectable_properties?type=this_is_not_a_valid_type')
+    response = client.get('/nodes/projections?type=this_is_not_a_valid_type')
     assert response.status_code == 422
 
 

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -10,7 +10,7 @@ from httpx import AsyncClient
 
 def test_get_user_projectable_properties(client: TestClient):
     """Test get projectable properties for users."""
-    response = client.get('/users/projectable_properties')
+    response = client.get('/users/projections')
     assert response.status_code == 200
     assert response.json() == sorted(orm.User.fields.keys())
 


### PR DESCRIPTION
They're services really. A REST repository (which is a typical dependency of a REST service) is actually the entity collection. Appropriately, we inject an entity to these classes and use their collection for repository-like actions. Hence, services.

### Peripheral changes

Moved node models from the router to a consolidate node.py module under the models package (including the model registry).