### PR TITLE
Discard endpoint docstrings

### DIFF
--- a/aiida_restapi/models/node.py
+++ b/aiida_restapi/models/node.py
@@ -38,11 +38,26 @@ class NodeStatistics(pdt.BaseModel):
 class NodeType(pdt.BaseModel):
     """Pydantic model representing a node type."""
 
-    label: str = pdt.Field(description='The class name of the node type.')
-    node_type: str = pdt.Field(description='The AiiDA node type string.')
-    nodes: str = pdt.Field(description='The URL to access nodes of this type.')
-    projections: str = pdt.Field(description='The URL to access projectable properties of this node type.')
-    node_schema: str = pdt.Field(description='The URL to access the schema of this node type.')
+    label: str = pdt.Field(
+        description='The class name of the node type.',
+        examples=['Int'],
+    )
+    node_type: str = pdt.Field(
+        description='The AiiDA node type string.',
+        examples=['data.core.int.Int.'],
+    )
+    nodes: str = pdt.Field(
+        description='The URL to access nodes of this type.',
+        examples=['../nodes?filters={"node_type":{"data.core.int.Int."}}'],
+    )
+    projections: str = pdt.Field(
+        description='The URL to access projectable properties of this node type.',
+        examples=['../nodes/projections?type=data.core.int.Int.'],
+    )
+    node_schema: str = pdt.Field(
+        description='The URL to access the schema of this node type.',
+        examples=['../nodes/schema?type=data.core.int.Int.'],
+    )
 
 
 class RepoFileMetadata(pdt.BaseModel):
@@ -50,16 +65,20 @@ class RepoFileMetadata(pdt.BaseModel):
 
     type: t.Literal['FILE'] = pdt.Field(
         description='The type of the repository object.',
+        examples=['FILE'],
     )
     binary: bool = pdt.Field(
         False,
         description='Whether the file is binary.',
+        examples=[True],
     )
     size: int = pdt.Field(
         description='The size of the file in bytes.',
+        examples=[1024],
     )
     download: str = pdt.Field(
         description='The URL to download the file.',
+        examples=['../nodes/{uuid}/repo/contents?filename=path/to/file.txt'],
     )
 
 
@@ -68,9 +87,24 @@ class RepoDirMetadata(pdt.BaseModel):
 
     type: t.Literal['DIRECTORY'] = pdt.Field(
         description='The type of the repository object.',
+        examples=['DIRECTORY'],
     )
     objects: dict[str, t.Union[RepoFileMetadata, 'RepoDirMetadata']] = pdt.Field(
         description='A dictionary with the metadata of the objects in the directory.',
+        examples=[
+            {
+                'file.txt': {
+                    'type': 'FILE',
+                    'binary': False,
+                    'size': 2048,
+                    'download': '../nodes/{uuid}/repo/contents?filename=path/to/file.txt',
+                },
+                'subdir': {
+                    'type': 'DIRECTORY',
+                    'objects': {},
+                },
+            }
+        ],
     )
 
 

--- a/aiida_restapi/routers/computers.py
+++ b/aiida_restapi/routers/computers.py
@@ -31,13 +31,7 @@ async def get_computers_schema(
         description='Type of schema to retrieve: "get" or "post"',
     ),
 ) -> dict:
-    """Get JSON schema for AiiDA computers.
-
-    :param which: The type of schema to retrieve: 'get' or 'post'.
-    :return: A dictionary with 'get' and 'post' keys containing the respective JSON schemas.
-    :raises HTTPException: 422 if the 'which' parameter is not 'get' or 'post',
-        500 for any other failures.
-    """
+    """Get JSON schema for AiiDA computers."""
     try:
         return service.get_schema(which=which)
     except ValueError as exception:
@@ -51,10 +45,7 @@ async def get_computers_schema(
     response_model=list[str],
 )
 async def get_computer_projections() -> list[str]:
-    """Get queryable projections for AiiDA computers.
-
-    :return: The list of queryable projections for AiiDA computers.
-    """
+    """Get queryable projections for AiiDA computers."""
     return service.get_projections()
 
 
@@ -68,11 +59,7 @@ async def get_computer_projections() -> list[str]:
 async def get_computers(
     queries: t.Annotated[QueryParams, Depends(query_params)],
 ) -> PaginatedResults[orm.Computer.Model]:
-    """Get AiiDA computers with optional filtering, sorting, and/or pagination.
-
-    :param queries: The query parameters, including filters, order_by, page_size, and page.
-    :return: The paginated results, including total count, current page, page size, and list of computer models.
-    """
+    """Get AiiDA computers with optional filtering, sorting, and/or pagination."""
     return service.get_many(queries)
 
 
@@ -84,13 +71,7 @@ async def get_computers(
 )
 @with_dbenv()
 async def get_computer(pk: str) -> orm.Computer.Model:
-    """Get AiiDA computer by pk.
-
-    :param pk: The pk of the AiiDA computer.
-    :return: The computer model.
-    :raises HTTPException: 404 if the computer with the given pk does not exist,
-        500 for any other failures.
-    """
+    """Get AiiDA computer by pk."""
     try:
         return service.get_one(pk)
     except NotExistent as exception:
@@ -105,13 +86,7 @@ async def get_computer(pk: str) -> orm.Computer.Model:
 )
 @with_dbenv()
 async def get_computer_metadata(pk: str) -> dict[str, t.Any]:
-    """Get metadata of an AiiDA computer by pk.
-
-    :param pk: The pk of the AiiDA computer.
-    :return: The metadata dictionary of the computer.
-    :raises HTTPException: 404 if the computer with the given pk does not exist,
-        500 for any other failures.
-    """
+    """Get metadata of an AiiDA computer by pk."""
     try:
         return service.get_field(pk, 'metadata')
     except NotExistent as exception:
@@ -131,13 +106,7 @@ async def create_computer(
     computer_model: orm.Computer.CreateModel,
     current_user: t.Annotated[UserInDB, Depends(get_current_active_user)],
 ) -> orm.Computer.Model:
-    """Create new AiiDA computer.
-
-    :param computer_model: The AiiDA ORM model of the computer to create.
-    :param current_user: The current authenticated user.
-    :return: The created AiiDA Computer model.
-    :raises HTTPException: 500 for any failures during computer creation.
-    """
+    """Create new AiiDA computer."""
     try:
         return service.add_one(computer_model)
     except Exception as exception:

--- a/aiida_restapi/routers/daemon.py
+++ b/aiida_restapi/routers/daemon.py
@@ -28,10 +28,7 @@ class DaemonStatusModel(BaseModel):
 )
 @with_dbenv()
 async def get_daemon_status() -> DaemonStatusModel:
-    """Return the daemon status.
-
-    :return: The daemon status.
-    """
+    """Return the daemon status."""
     client = get_daemon_client()
 
     if not client.is_daemon_running:
@@ -53,11 +50,7 @@ async def get_daemon_status() -> DaemonStatusModel:
 async def get_daemon_start(
     current_user: t.Annotated[UserInDB, Depends(get_current_active_user)],
 ) -> DaemonStatusModel:
-    """Start the daemon.
-
-    :return: The daemon status after starting.
-    :raises HTTPException: If the daemon is already running (400) or if there was an error starting it (500).
-    """
+    """Start the daemon."""
     client = get_daemon_client()
 
     if client.is_daemon_running:
@@ -80,11 +73,7 @@ async def get_daemon_start(
 async def get_daemon_stop(
     current_user: t.Annotated[UserInDB, Depends(get_current_active_user)],
 ) -> DaemonStatusModel:
-    """Stop the daemon.
-
-    :return: The daemon status after stopping.
-    :raises HTTPException: If the daemon is not running (400) or if there was an error stopping it (500).
-    """
+    """Stop the daemon."""
     client = get_daemon_client()
 
     if not client.is_daemon_running:

--- a/aiida_restapi/routers/groups.py
+++ b/aiida_restapi/routers/groups.py
@@ -31,13 +31,7 @@ async def get_groups_schema(
         description='Type of schema to retrieve: "get" or "post"',
     ),
 ) -> dict:
-    """Get JSON schema for AiiDA groups.
-
-    :param which: The type of schema to retrieve: 'get' or 'post'.
-    :return: A dictionary with 'get' and 'post' keys containing the respective JSON schemas.
-    :raises HTTPException: 422 if the 'which' parameter is not 'get' or 'post',
-        500 for any other failures.
-    """
+    """Get JSON schema for AiiDA groups."""
     try:
         return service.get_schema(which=which)
     except ValueError as exception:
@@ -51,10 +45,7 @@ async def get_groups_schema(
     response_model=list[str],
 )
 async def get_group_projections() -> list[str]:
-    """Get queryable projections for AiiDA groups.
-
-    :return: The list of queryable projections for AiiDA groups.
-    """
+    """Get queryable projections for AiiDA groups."""
     return service.get_projections()
 
 
@@ -68,11 +59,7 @@ async def get_group_projections() -> list[str]:
 async def get_groups(
     queries: t.Annotated[QueryParams, Depends(query_params)],
 ) -> PaginatedResults[orm.Group.Model]:
-    """Get AiiDA groups with optional filtering, sorting, and/or pagination.
-
-    :param queries: The query parameters, including filters, order_by, page_size, and page.
-    :return: The paginated results, including total count, current page, page size, and list of group models.
-    """
+    """Get AiiDA groups with optional filtering, sorting, and/or pagination."""
     return service.get_many(queries)
 
 
@@ -84,13 +71,7 @@ async def get_groups(
 )
 @with_dbenv()
 async def get_group(uuid: str) -> orm.Group.Model:
-    """Get AiiDA group by uuid.
-
-    :param uuid: The uuid of the group to retrieve.
-    :return: The AiiDA group model.
-    :raises HTTPException: 404 if a group with the given uuid does not exist,
-        500 for any other server error.
-    """
+    """Get AiiDA group by uuid."""
     try:
         return service.get_one(uuid)
     except NotExistent as exception:
@@ -105,13 +86,7 @@ async def get_group(uuid: str) -> orm.Group.Model:
 )
 @with_dbenv()
 async def get_group_extras(uuid: str) -> dict[str, t.Any]:
-    """Get the extras of a group.
-
-    :param uuid: The uuid of the group to retrieve the extras for.
-    :return: A dictionary with the group extras.
-    :raises HTTPException: 404 if the group with the given uuid does not exist,
-        500 for other failures during retrieval.
-    """
+    """Get the extras of a group."""
     try:
         return service.get_field(uuid, 'extras')
     except NotExistent as exception:
@@ -131,13 +106,7 @@ async def create_group(
     group_model: orm.Group.CreateModel,
     current_user: t.Annotated[UserInDB, Depends(get_current_active_user)],
 ) -> orm.Group.Model:
-    """Create new AiiDA group.
-
-    :param group_model: The Pydantic model of the group to create.
-    :param current_user: The current authenticated user.
-    :return: The created AiiDA Group model.
-    :raises HTTPException: 500 for any failures during group creation.
-    """
+    """Create new AiiDA group."""
     try:
         return service.add_one(group_model)
     except Exception as exception:

--- a/aiida_restapi/routers/nodes.py
+++ b/aiida_restapi/routers/nodes.py
@@ -49,18 +49,10 @@ async def get_nodes_schema(
     ),
     which: t.Literal['get', 'post'] = Query(
         'get',
-        description='The type of schema to retrieve: "get" for the response model, "post" for the creation model.',
+        description='Type of schema to retrieve',
     ),
 ) -> dict:
-    """Get JSON schema for the base AiiDA node 'get' model.
-
-    :param node_type: The AiiDA node type string.
-    :param which: The type of schema to retrieve: 'get' or 'post'.
-    :return: The JSON schema for the base AiiDA node 'get' model.
-    :raises HTTPException: 422 if the 'which' parameter is not 'get' or 'post',
-        422 if the node type is not recognized,
-        500 for any other failures.
-    """
+    """Get JSON schema for the base AiiDA node 'get' model."""
     if not node_type:
         return orm.Node.Model.model_json_schema()
     try:
@@ -84,13 +76,7 @@ async def get_node_projections(
         alias='type',
     ),
 ) -> list[str]:
-    """Get queryable projections for AiiDA nodes.
-
-    :param node_type: The AiiDA node type string.
-    :return: The list of queryable projections for AiiDA nodes.
-    :raises HTTPException: 422 if the node type is not recognized,
-        500 for any other failures.
-    """
+    """Get queryable projections for AiiDA nodes."""
     try:
         return service.get_projections(node_type)
     except ValueError as exception:
@@ -105,25 +91,7 @@ async def get_node_projections(
 )
 @with_dbenv()
 async def get_nodes_statistics(user: int | None = None) -> dict[str, t.Any]:
-    """Get node statistics.
-
-    :param user: Optional user PK to filter statistics by user.
-    :return: A dictionary containing total node count, counts by node type, and creation time statistics.
-
-    >>> {
-    >>>   "total": 47,
-    >>>   "types": {
-    >>>       "data.core.int.Int.": 42,
-    >>>       "data.core.singlefile.SinglefileData.": 5,
-    >>>       ...
-    >>>   },
-    >>>   "ctime_by_day": {
-    >>>       "2012-01-01": 10,
-    >>>       "2012-01-02": 15,
-    >>>       ...
-    >>>   },
-    >>> }
-    """
+    """Get node statistics."""
 
     from aiida.manage import get_manager
 
@@ -133,12 +101,7 @@ async def get_nodes_statistics(user: int | None = None) -> dict[str, t.Any]:
 
 @read_router.get('/download_formats')
 async def get_nodes_download_formats() -> dict[str, t.Any]:
-    """Get download formats for AiiDA nodes.
-
-    :return: A dictionary with available download formats as keys and their descriptions as values.
-    :raises HTTPException: 404 if the download formats are not available,
-        500 for other failures during retrieval.
-    """
+    """Get download formats for AiiDA nodes."""
     try:
         return service.get_download_formats()
     except EntryPointError as exception:
@@ -157,11 +120,7 @@ async def get_nodes_download_formats() -> dict[str, t.Any]:
 async def get_nodes(
     queries: t.Annotated[QueryParams, Depends(query_params)],
 ) -> PaginatedResults[orm.Node.Model]:
-    """Get AiiDA nodes with optional filtering, sorting, and/or pagination.
-
-    :param queries: The query parameters, including filters, order_by, page_size, and page.
-    :return: The paginated results, including total count, current page, page size, and list of node models.
-    """
+    """Get AiiDA nodes with optional filtering, sorting, and/or pagination."""
     return service.get_many(queries)
 
 
@@ -170,21 +129,7 @@ async def get_nodes(
     response_model=list[NodeType],
 )
 async def get_node_types() -> list:
-    """Get all node types in machine-actionable format.
-
-    :return: A list of dictionaries, each containing information about a node type, e.g.:
-
-    >>> [
-    >>>   {
-    >>>     "label": "Int",
-    >>>     "node_type": "data.core.int.Int.",
-    >>>     "nodes": ".../nodes?filters={\"node_type\":{\"data.core.int.Int.\"}}",
-    >>>     "projections": ".../nodes/projections?type=data.core.int.Int.",
-    >>>     "node_schema": ".../nodes/schema?type=data.core.int.Int.",
-    >>>   },
-    >>>   ...
-    >>> ]
-    """
+    """Get all node types in machine-actionable format."""
     api_prefix = API_CONFIG['PREFIX']
     return [
         {
@@ -208,13 +153,7 @@ async def get_node_types() -> list:
 )
 @with_dbenv()
 async def get_node(uuid: str) -> orm.Node.Model:
-    """Get AiiDA node by uuid.
-
-    :param uuid: The uuid of the node to retrieve.
-    :return: The AiiDA node model, e.g. `orm.Node.Model`,
-    :raises HTTPException: 422 if the node with the given uuid does not exist,
-        500 for other failures during retrieval.
-    """
+    """Get AiiDA node by uuid."""
     try:
         return service.get_one(uuid)
     except NotExistent as exception:
@@ -229,13 +168,7 @@ async def get_node(uuid: str) -> orm.Node.Model:
 )
 @with_dbenv()
 async def get_node_attributes(uuid: str) -> dict[str, t.Any]:
-    """Get the attributes of a node.
-
-    :param uuid: The uuid of the node to retrieve the attributes for.
-    :return: A dictionary with the node attributes.
-    :raises HTTPException: 404 if the node with the given uuid does not exist,
-        500 for other failures during retrieval.
-    """
+    """Get the attributes of a node."""
     try:
         return service.get_field(uuid, 'attributes')
     except NotExistent as exception:
@@ -250,13 +183,7 @@ async def get_node_attributes(uuid: str) -> dict[str, t.Any]:
 )
 @with_dbenv()
 async def get_node_extras(uuid: str) -> dict[str, t.Any]:
-    """Get the extras of a node.
-
-    :param uuid: The uuid of the node to retrieve the extras for.
-    :return: A dictionary with the node extras.
-    :raises HTTPException: 404 if the node with the given uuid does not exist,
-        500 for other failures during retrieval.
-    """
+    """Get the extras of a node."""
     try:
         return service.get_field(uuid, 'extras')
     except NotExistent as exception:
@@ -279,15 +206,7 @@ async def get_node_links(
         description='Specify whether to retrieve incoming or outgoing links.',
     ),
 ) -> PaginatedResults[NodeLink]:
-    """Get the incoming or outgoing links of a node.
-
-    :param uuid: The uuid of the node to retrieve the incoming links for.
-    :param queries: The query parameters, including filters, order_by, page_size, and page.
-    :param direction: Specify whether to retrieve incoming or outgoing links.
-    :return: The paginated requested linked nodes.
-    :raises HTTPException: 404 if the node with the given uuid does not exist,
-        500 for other failures during retrieval.
-    """
+    """Get the incoming or outgoing links of a node."""
     try:
         return service.get_links(uuid, queries, direction=direction)
     except NotExistent as exception:
@@ -308,16 +227,7 @@ async def download_node(
         description='Format to download the node in',
     ),
 ) -> StreamingResponse:
-    """Download AiiDA node by uuid in a given download format provided as a query parameter.
-
-    :param uuid: The uuid of the node to retrieve.
-    :param download_format: The format to download the node in.
-    :return: StreamingResponse with the exported node content.
-    :raises HTTPException: 403 if licensing restrictions prevent export,
-        404 if the node with the given uuid does not exist,
-        422 if the download format is not specified, or if the download format is not supported,
-        500 for other failures during retrieval.
-    """
+    """Download AiiDA node by uuid in a given download format provided as a query parameter."""
     try:
         node = orm.load_node(uuid)
     except NotExistent as exception:
@@ -362,13 +272,7 @@ async def download_node(
 )
 @with_dbenv()
 async def get_node_repo_file_metadata(uuid: str) -> dict[str, dict]:
-    """Get the repository file metadata of a node.
-
-    :param uuid: The uuid of the node to retrieve the repository metadata for.
-    :return: A dictionary with the repository file metadata.
-    :raises HTTPException: 404 if the node with the given uuid does not exist,
-        500 for other failures during retrieval.
-    """
+    """Get the repository file metadata of a node."""
     try:
         return service.get_repository_metadata(uuid)
     except NotExistent as exception:
@@ -389,14 +293,7 @@ async def get_node_repo_file_contents(
         description='Filename of repository content to retrieve',
     ),
 ) -> StreamingResponse:
-    """Get the repository contents of a node.
-
-    :param uuid: The uuid of the node to retrieve the repository contents for.
-    :param filename: The filename of the repository content to retrieve. If None, retrieves all contents.
-    :return: StreamingResponse with the requested file content.
-    :raises HTTPException: 404 if the node with the given uuid does not exist,
-        404 if the requested file does not exist in the node's repository.
-    """
+    """Get the repository contents of a node."""
     from urllib.parse import quote
 
     try:
@@ -447,14 +344,7 @@ async def create_node(
     model: NodeModelUnion,
     current_user: t.Annotated[UserInDB, Depends(get_current_active_user)],
 ) -> orm.Node.Model:
-    """Create new AiiDA node.
-
-    :param model: The AiiDA ORM model of the node to create.
-    :param current_user: The current authenticated user.
-    :return: The serialized created AiiDA node.
-    :raises HTTPException: 422 if the node type is not recognized,
-        500 for other failures during node creation.
-    """
+    """Create new AiiDA node."""
     try:
         return service.add_one(model)
     except KeyError as exception:
@@ -475,18 +365,7 @@ async def create_node_with_files(
     files: list[UploadFile],
     current_user: t.Annotated[UserInDB, Depends(get_current_active_user)],
 ) -> orm.Node.Model:
-    """Create new AiiDA node with files.
-
-    :param params: The JSON string representing the AiiDA ORM model of the node to create.
-    :param files: The list of uploaded files.
-    :param current_user: The current authenticated user.
-    :return: The serialized created AiiDA node.
-    :raises HTTPException: 400 if the JSON is invalid,
-        422 if the node type is not recognized,
-        422 if validation of the node model fails,
-        422 if any uploaded file has an invalid path or if there are duplicate target paths,
-        500 for other failures during node creation.
-    """
+    """Create new AiiDA node with files."""
     try:
         parameters = t.cast(dict, json.loads(params))
     except json.JSONDecodeError as exception:

--- a/aiida_restapi/routers/querybuilder.py
+++ b/aiida_restapi/routers/querybuilder.py
@@ -123,13 +123,7 @@ async def query_builder(
         description='Whether to return results flat.',
     ),
 ) -> PaginatedResults:
-    """Execute a QueryBuilder query based on the provided dictionary.
-
-    :param query: The QueryBuilder query dictionary.
-    :param flat: Whether to return results flat.
-    :return: The results of the QueryBuilder query.
-    :raises HTTPException: 400 if the query is invalid.
-    """
+    """Execute a QueryBuilder query based on the provided dictionary."""
     query_dict = query.model_dump()
 
     try:

--- a/aiida_restapi/routers/server.py
+++ b/aiida_restapi/routers/server.py
@@ -19,11 +19,26 @@ read_router = APIRouter(prefix='/server')
 class ServerInfo(pdt.BaseModel):
     """API version information."""
 
-    api_major_version: str = pdt.Field(description='Major version of the API')
-    api_minor_version: str = pdt.Field(description='Minor version of the API')
-    api_revision_version: str = pdt.Field(description='Revision version of the API')
-    api_prefix: str = pdt.Field(description='Prefix for all API endpoints')
-    aiida_version: str = pdt.Field(description='Version of the AiiDA installation')
+    api_major_version: str = pdt.Field(
+        description='Major version of the API',
+        examples=['0'],
+    )
+    api_minor_version: str = pdt.Field(
+        description='Minor version of the API',
+        examples=['1'],
+    )
+    api_revision_version: str = pdt.Field(
+        description='Revision version of the API',
+        examples=['0a1'],
+    )
+    api_prefix: str = pdt.Field(
+        description='Prefix for all API endpoints',
+        examples=['/api/v0'],
+    )
+    aiida_version: str = pdt.Field(
+        description='Version of the AiiDA installation',
+        examples=['2.8.0'],
+    )
 
 
 @read_router.get(
@@ -45,10 +60,23 @@ async def get_server_info() -> dict[str, str]:
 class ServerEndpoint(pdt.BaseModel):
     """API endpoint."""
 
-    path: str = pdt.Field(description='Path of the endpoint')
-    group: str | None = pdt.Field(description='Group of the endpoint')
-    methods: set[str] = pdt.Field(description='HTTP methods supported by the endpoint')
-    description: str = pdt.Field('-', description='Description of the endpoint')
+    path: str = pdt.Field(
+        description='Path of the endpoint',
+        examples=['../server/endpoints'],
+    )
+    group: str | None = pdt.Field(
+        description='Group of the endpoint',
+        examples=['server'],
+    )
+    methods: set[str] = pdt.Field(
+        description='HTTP methods supported by the endpoint',
+        examples=['GET'],
+    )
+    description: str = pdt.Field(
+        '-',
+        description='Description of the endpoint',
+        examples=['Get a JSON-serializable dictionary of all registered API routes.'],
+    )
 
 
 @read_router.get(
@@ -56,11 +84,7 @@ class ServerEndpoint(pdt.BaseModel):
     response_model=dict[str, list[ServerEndpoint]],
 )
 async def get_server_endpoints(request: Request) -> dict[str, list[dict]]:
-    """Get a JSON-serializable dictionary of all registered API routes.
-
-    :param request: The FastAPI request object.
-    :return: A JSON-serializable dictionary of all registered API routes.
-    """
+    """Get a JSON-serializable dictionary of all registered API routes."""
     endpoints: list[dict] = []
 
     for route in request.app.routes:
@@ -88,11 +112,7 @@ async def get_server_endpoints(request: Request) -> dict[str, list[dict]]:
     response_class=HTMLResponse,
 )
 async def get_server_endpoints_table(request: Request) -> HTMLResponse:
-    """Get an HTML table of all registered API routes.
-
-    :param request: The FastAPI request object.
-    :return: An HTML table of all registered API routes.
-    """
+    """Get an HTML table of all registered API routes."""
     routes = request.app.routes
     base_url = str(request.base_url).rstrip('/')
 

--- a/aiida_restapi/routers/submit.py
+++ b/aiida_restapi/routers/submit.py
@@ -43,9 +43,19 @@ def process_inputs(inputs: dict[str, t.Any]) -> dict[str, t.Any]:
 
 
 class ProcessSubmitModel(pdt.BaseModel):
-    label: str = pdt.Field(default='', description='The label of the process')
-    entry_point: str = pdt.Field(description='The entry point of the process')
-    inputs: dict[str, t.Any] = pdt.Field(description='The inputs of the process')
+    label: str = pdt.Field(
+        '',
+        description='The label of the process',
+        examples=['My process', 'Test calculation'],
+    )
+    entry_point: str = pdt.Field(
+        description='The entry point of the process',
+        examples=['core.arithmetic.add'],
+    )
+    inputs: dict[str, t.Any] = pdt.Field(
+        description='The inputs of the process',
+        examples=[{'x': 1, 'y': 2}],
+    )
 
     @pdt.field_validator('inputs')
     @classmethod
@@ -69,14 +79,7 @@ async def submit_process(
     process: ProcessSubmitModel,
     current_user: t.Annotated[UserInDB, Depends(get_current_active_user)],
 ) -> orm.Node.Model:
-    """Submit new AiiDA process.
-
-    :param process: The Pydantic model of the process to create.
-    :param current_user: The current authenticated user.
-    :return: The created process node model.
-    :raises HTTPException: 404 if the entry point is not recognized,
-        500 for other failures during process submission.
-    """
+    """Submit new AiiDA process."""
     try:
         entry_point_process = load_entry_point_from_string(process.entry_point)
         process_node = engine.submit(entry_point_process, **process.inputs)

--- a/aiida_restapi/routers/users.py
+++ b/aiida_restapi/routers/users.py
@@ -31,13 +31,7 @@ async def get_users_schema(
         description='Type of schema to retrieve: "get" or "post"',
     ),
 ) -> dict:
-    """Get JSON schema for AiiDA users.
-
-    :param which: The type of schema to retrieve: 'get' or 'post'.
-    :return: A dictionary with 'get' and 'post' keys containing the respective JSON schemas.
-    :raises HTTPException: 422 if the 'which' parameter is not 'get' or 'post',
-        500 for any other failures.
-    """
+    """Get JSON schema for AiiDA users."""
     try:
         return service.get_schema(which=which)
     except ValueError as exception:
@@ -51,10 +45,7 @@ async def get_users_schema(
     response_model=list[str],
 )
 async def get_user_projections() -> list[str]:
-    """Get queryable projections for AiiDA users.
-
-    :return: The list of queryable projections for AiiDA users.
-    """
+    """Get queryable projections for AiiDA users."""
     return service.get_projections()
 
 
@@ -68,11 +59,7 @@ async def get_user_projections() -> list[str]:
 async def get_users(
     queries: t.Annotated[QueryParams, Depends(query_params)],
 ) -> PaginatedResults[orm.User.Model]:
-    """Get AiiDA users with optional filtering, sorting, and/or pagination.
-
-    :param queries: The query parameters, including filters, order_by, page_size, and page.
-    :return: The paginated results, including total count, current page, page size, and list of user models.
-    """
+    """Get AiiDA users with optional filtering, sorting, and/or pagination."""
     return service.get_many(queries)
 
 
@@ -82,13 +69,7 @@ async def get_users(
 )
 @with_dbenv()
 async def get_user(pk: int) -> orm.User.Model:
-    """Get AiiDA user by pk.
-
-    :param pk: The pk of the user to retrieve.
-    :return: The AiiDA user model.
-    :raises HTTPException: 404 if the user with the given pk does not exist,
-        500 for any other failures.
-    """
+    """Get AiiDA user by pk."""
     try:
         return service.get_one(pk)
     except NotExistent as exception:
@@ -108,13 +89,7 @@ async def create_user(
     user_model: orm.User.CreateModel,
     current_user: t.Annotated[UserInDB, Depends(get_current_active_user)],
 ) -> orm.User.Model:
-    """Create new AiiDA user.
-
-    :param user_model: The Pydantic model of the user to create.
-    :param current_user: The current authenticated user.
-    :return: The created AiiDA User model.
-    :raises HTTPException: 500 for any failures during user creation.
-    """
+    """Create new AiiDA user."""
     try:
         return service.add_one(user_model)
     except Exception as exception:


### PR DESCRIPTION
FastAPI provides automatic and rich documentation from endpoint metadata (response model, parameter types, etc.). There is no need to provide our own.