### PR TITLE
Relationship endpoints

### DIFF
--- a/aiida_restapi/routers/groups.py
+++ b/aiida_restapi/routers/groups.py
@@ -101,6 +101,29 @@ async def get_group_user(uuid: str) -> orm.User.Model:
 
 
 @read_router.get(
+    '/{uuid}/nodes',
+    response_model=PaginatedResults[orm.Node.Model],
+    response_model_exclude_none=True,
+    response_model_exclude_unset=True,
+    responses={
+        404: {'model': errors.NonExistentError},
+        409: {'model': errors.MultipleObjectsError},
+        422: {'model': t.Union[errors.RequestValidationError, errors.QueryBuilderError]},
+    },
+)
+@with_dbenv()
+async def get_group_nodes(
+    uuid: str,
+    query_params: t.Annotated[
+        query.QueryParams,
+        Depends(query.query_params),
+    ],
+) -> PaginatedResults[orm.Node.Model]:
+    """Get the nodes of a group."""
+    return service.get_related_many(uuid, orm.Node, query_params)
+
+
+@read_router.get(
     '/{uuid}/extras',
     response_model=dict[str, t.Any],
     responses={

--- a/aiida_restapi/routers/groups.py
+++ b/aiida_restapi/routers/groups.py
@@ -84,6 +84,23 @@ async def get_group(uuid: str) -> orm.Group.Model:
 
 
 @read_router.get(
+    '/{uuid}/user',
+    response_model=orm.User.Model,
+    response_model_exclude_none=True,
+    response_model_exclude_unset=True,
+    responses={
+        404: {'model': errors.NonExistentError},
+        409: {'model': errors.MultipleObjectsError},
+        422: {'model': errors.RequestValidationError},
+    },
+)
+@with_dbenv()
+async def get_group_user(uuid: str) -> orm.User.Model:
+    """Get the user associated with a group."""
+    return t.cast(orm.User.Model, service.get_related_one(uuid, orm.User))
+
+
+@read_router.get(
     '/{uuid}/extras',
     response_model=dict[str, t.Any],
     responses={

--- a/aiida_restapi/routers/nodes.py
+++ b/aiida_restapi/routers/nodes.py
@@ -198,6 +198,29 @@ async def get_node_computer(uuid: str) -> orm.Computer.Model:
 
 
 @read_router.get(
+    '/{uuid}/groups',
+    response_model=PaginatedResults[orm.Group.Model],
+    response_model_exclude_none=True,
+    response_model_exclude_unset=True,
+    responses={
+        404: {'model': errors.NonExistentError},
+        409: {'model': errors.MultipleObjectsError},
+        422: {'model': t.Union[errors.RequestValidationError, errors.QueryBuilderError]},
+    },
+)
+@with_dbenv()
+async def get_node_groups(
+    uuid: str,
+    query_params: t.Annotated[
+        query.QueryParams,
+        Depends(query.query_params),
+    ],
+) -> PaginatedResults[orm.Group.Model]:
+    """Get the groups of a node."""
+    return service.get_related_many(uuid, orm.Group, query_params)
+
+
+@read_router.get(
     '/{uuid}/attributes',
     response_model=dict[str, t.Any],
     responses={

--- a/aiida_restapi/routers/nodes.py
+++ b/aiida_restapi/routers/nodes.py
@@ -164,6 +164,40 @@ async def get_node(uuid: str) -> orm.Node.Model:
 
 
 @read_router.get(
+    '/{uuid}/user',
+    response_model=orm.User.Model,
+    response_model_exclude_none=True,
+    response_model_exclude_unset=True,
+    responses={
+        404: {'model': errors.NonExistentError},
+        409: {'model': errors.MultipleObjectsError},
+        422: {'model': errors.RequestValidationError},
+    },
+)
+@with_dbenv()
+async def get_node_user(uuid: str) -> orm.User.Model:
+    """Get the user associated with a node."""
+    return t.cast(orm.User.Model, service.get_related_one(uuid, orm.User))
+
+
+@read_router.get(
+    '/{uuid}/computer',
+    response_model=orm.Computer.Model,
+    response_model_exclude_none=True,
+    response_model_exclude_unset=True,
+    responses={
+        404: {'model': errors.NonExistentError},
+        409: {'model': errors.MultipleObjectsError},
+        422: {'model': errors.RequestValidationError},
+    },
+)
+@with_dbenv()
+async def get_node_computer(uuid: str) -> orm.Computer.Model:
+    """Get the computer associated with a node."""
+    return t.cast(orm.Computer.Model, service.get_related_one(uuid, orm.Computer))
+
+
+@read_router.get(
     '/{uuid}/attributes',
     response_model=dict[str, t.Any],
     responses={

--- a/aiida_restapi/services/entity.py
+++ b/aiida_restapi/services/entity.py
@@ -168,7 +168,7 @@ class EntityService(t.Generic[EntityType, EntityModelType]):
 
         try:
             total = qb.count()
-            results = qb.all()
+            results = qb.all(flat=True)
         except Exception as exception:
             raise QueryBuilderException(str(exception)) from exception
 
@@ -176,7 +176,7 @@ class EntityService(t.Generic[EntityType, EntityModelType]):
             total=total,
             page=query_params.page,
             page_size=query_params.page_size,
-            data=[self._to_model(result[0]) for result in results],
+            data=[self._to_model(result) for result in results],
         )
 
     def get_field(self, identifier: str | int, field: str) -> t.Any:

--- a/aiida_restapi/services/node.py
+++ b/aiida_restapi/services/node.py
@@ -35,6 +35,8 @@ class NodeService(EntityService[NodeType, NodeModelType]):
     LIKE_OPERATOR_CHARACTER = '%'
     DEFAULT_NAMESPACE_LABEL = '~no-entry-point~'
 
+    with_key = 'node'
+
     def get_projections(self, node_type: str | None = None) -> list[str]:
         """Get projectable properties for the AiiDA entity.
 

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -48,6 +48,18 @@ def test_get_group_user(client: TestClient):
     orm.Group.collection.delete(group.pk)
 
 
+def test_get_group_nodes(client: TestClient, default_nodes: list[str]):
+    """Test retrieving nodes of a single group."""
+    group = orm.Group(label='test_group_nodes').store()
+    group.add_nodes([orm.load_node(node_id) for node_id in default_nodes])
+    response = client.get(f'/groups/{group.uuid}/nodes')
+    assert response.status_code == 200
+    data = response.json()['data']
+    returned_node_ids = {item['uuid'] for item in data}
+    assert returned_node_ids == set(default_nodes)
+    orm.Group.collection.delete(group.pk)
+
+
 def test_get_group_extras(client: TestClient):
     """Test retrieving extras of a single group."""
     group = orm.Group(label='test_group_extras').store()

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -38,6 +38,16 @@ def test_get_group(client: TestClient, default_groups: list[str]):
         assert response.status_code == 200
 
 
+def test_get_group_user(client: TestClient):
+    """Test retrieving the user of a single group."""
+    group = orm.Group(label='test_group_user').store()
+    response = client.get(f'/groups/{group.uuid}/user')
+    assert response.status_code == 200
+    data = response.json()
+    assert data['email'] == group.user.email
+    orm.Group.collection.delete(group.pk)
+
+
 def test_get_group_extras(client: TestClient):
     """Test retrieving extras of a single group."""
     group = orm.Group(label='test_group_extras').store()

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -45,7 +45,6 @@ def test_get_group_user(client: TestClient):
     assert response.status_code == 200
     data = response.json()
     assert data['email'] == group.user.email
-    orm.Group.collection.delete(group.pk)
 
 
 def test_get_group_nodes(client: TestClient, default_nodes: list[str]):
@@ -57,7 +56,6 @@ def test_get_group_nodes(client: TestClient, default_nodes: list[str]):
     data = response.json()['data']
     returned_node_ids = {item['uuid'] for item in data}
     assert returned_node_ids == set(default_nodes)
-    orm.Group.collection.delete(group.pk)
 
 
 def test_get_group_extras(client: TestClient):

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -243,6 +243,20 @@ def test_get_node_computer(client: TestClient):
     orm.Int.collection.delete(node.pk)
 
 
+def test_get_node_groups(client: TestClient, default_groups: list[str]):
+    """Test retrieving groups of a single node."""
+    node = orm.Int(value=10).store()
+    for group_id in default_groups:
+        group = orm.load_group(group_id)
+        group.add_nodes([node])
+    response = client.get(f'/nodes/{node.uuid}/groups')
+    assert response.status_code == 200
+    data = response.json()['data']
+    returned_group_ids = {item['uuid'] for item in data}
+    assert returned_group_ids == set(default_groups)
+    orm.Int.collection.delete(node.pk)
+
+
 def test_get_node_attributes(client: TestClient, default_nodes: list[str | None]):
     """Test retrieving attributes of a single node."""
     for node_id in default_nodes:

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -223,6 +223,26 @@ def test_get_node(client: TestClient, default_nodes: list[str | None]):
         assert response.json()['uuid'] == node_id
 
 
+def test_get_node_user(client: TestClient):
+    """Test retrieving the user of a single node."""
+    node = orm.Int(value=5).store()
+    response = client.get(f'/nodes/{node.uuid}/user')
+    assert response.status_code == 200
+    data = response.json()
+    assert data['email'] == node.user.email
+    orm.Int.collection.delete(node.pk)
+
+
+def test_get_node_computer(client: TestClient):
+    """Test retrieving the computer of a single node."""
+    node = orm.Int(value=5).store()
+    response = client.get(f'/nodes/{node.uuid}/computer')
+    assert response.status_code == 200
+    data = response.json()
+    assert data['pk'] == node.computer.pk
+    orm.Int.collection.delete(node.pk)
+
+
 def test_get_node_attributes(client: TestClient, default_nodes: list[str | None]):
     """Test retrieving attributes of a single node."""
     for node_id in default_nodes:


### PR DESCRIPTION
This PR implements related-entity endpoints for fetching:
- [x] A group's user
- [x] All nodes in a group
- [x] A node's user
- [x] A node's computer
- [x] All groups containing a given node