### PR TITLE
Simplify node download endpoint

### DIFF
--- a/aiida_restapi/cli/main.py
+++ b/aiida_restapi/cli/main.py
@@ -15,7 +15,17 @@ def cli() -> None:
 @click.option('--read-only', is_flag=True)
 @click.option('--watch', is_flag=True)
 def start(read_only: bool, watch: bool, host: str, port: int) -> None:
-    """Start the AiiDA REST API service."""
+    """Start the AiiDA REST API service.
+
+    :param read_only: If set, the API will be started in read-only mode.
+    :type read_only: bool
+    :param watch: If set, the API will watch for code changes and reload automatically.
+    :type watch: bool
+    :param host: The host address to bind the API service to.
+    :type host: str
+    :param port: The port number to bind the API service to.
+    :type port: int
+    """
 
     os.environ['AIIDA_RESTAPI_READ_ONLY'] = '1' if read_only else '0'
 

--- a/aiida_restapi/common/query.py
+++ b/aiida_restapi/common/query.py
@@ -58,10 +58,15 @@ def query_params(
     """Parse query parameters into a structured object.
 
     :param filters: AiiDA QueryBuilder filters as JSON string.
+    :type filters: str | None
     :param order_by: Comma-separated string of fields to sort by.
+    :type order_by: str | None
     :param page_size: Number of results per page.
+    :type page_size: pdt.PositiveInt
     :param page: Page number.
+    :type page: pdt.PositiveInt
     :return: Structured query parameters.
+    :rtype: QueryParams
     :raises HTTPException: If filters cannot be parsed as JSON.
     """
     query_filters: dict[str, t.Any] = {}

--- a/aiida_restapi/models/node.py
+++ b/aiida_restapi/models/node.py
@@ -153,7 +153,9 @@ class NodeModelRegistry:
         """Get the AiiDA node class name for a given node type.
 
         :param node_type: The AiiDA node type string.
+        :type node_type: str
         :return: The corresponding node class name.
+        :rtype: str
         """
         return node_type.rsplit('.', 2)[-2]
 
@@ -161,7 +163,9 @@ class NodeModelRegistry:
         """Get the Pydantic model class for a given node type.
 
         :param node_type: The AiiDA node type string.
+        :type node_type: str
         :return: The corresponding Pydantic model class.
+        :rtype: type[Node.Model]
         """
         if (Model := self._models.get(node_type)) is None:
             raise MissingEntryPointError(f'Unknown node type: {node_type}')
@@ -173,7 +177,9 @@ class NodeModelRegistry:
         """Return a patched Model for the given node class with a literal `node_type` field.
 
         :param node_cls: The AiiDA node class.
+        :type node_cls: Node
         :return: The patched ORM Node model.
+        :rtype: type[Node.Model]
         """
         Model = node_cls.CreateModel
         node_type = node_cls.class_node_type
@@ -207,6 +213,7 @@ class NodeModelRegistry:
         """Get a union type of all node 'post' models.
 
         :return: A union type of all node 'post' models.
+        :rtype: tuple[type[Node.Model], ...]
         """
         post_models = [model_dict['post'] for model_dict in self._models.values()]
         return tuple(post_models)

--- a/aiida_restapi/routers/nodes.py
+++ b/aiida_restapi/routers/nodes.py
@@ -354,7 +354,7 @@ async def get_node_repo_file_contents(
 @with_dbenv()
 async def download_node(
     uuid: str,
-    download_format: t.Annotated[
+    format: t.Annotated[
         str | None,
         Query(description='Format to download the node in'),
     ] = None,
@@ -362,27 +362,27 @@ async def download_node(
     """Download AiiDA node by uuid in a given download format provided as a query parameter."""
     node = orm.load_node(uuid)
 
-    if download_format is None:
+    if format is None:
         raise ValidationException(
             'Please specify the download format. '
             'The available download formats can be '
             'queried using the /nodes/download_formats/ endpoint.',
         )
 
-    if download_format in node.get_export_formats():
+    if format in node.get_export_formats():
         # byteobj, dict with {filename: filecontent}
-        exported_bytes, _ = node._exportcontent(download_format)
+        exported_bytes, _ = node._exportcontent(format)
 
         def stream() -> t.Generator[bytes, None, None]:
             with io.BytesIO(exported_bytes) as handler:
                 yield from handler
 
-        return StreamingResponse(stream(), media_type=f'application/{download_format}')
+        return StreamingResponse(stream(), media_type=f'application/{format}')
 
     raise ValidationException(
         'The format {} is not supported. '
         'The available download formats can be '
-        'queried using the /nodes/download_formats/ endpoint.'.format(download_format),
+        'queried using the /nodes/download_formats/ endpoint.'.format(format),
     )
 
 

--- a/aiida_restapi/routers/server.py
+++ b/aiida_restapi/routers/server.py
@@ -170,7 +170,9 @@ def _get_route_parts(route: Route) -> tuple[str | None, set[str], str]:
     """Return the parts of a route: path, group, methods, description.
 
     :param route: A FastAPI/Starlette Route object.
+    :type route: Route
     :return: A tuple containing the group, methods, and description of the route.
+    :rtype: tuple[str | None, set[str], str]
     """
     prefix = re.escape(API_CONFIG['PREFIX'])
     match = re.match(rf'^{prefix}/([^/]+)/?.*', route.path)

--- a/aiida_restapi/routers/submit.py
+++ b/aiida_restapi/routers/submit.py
@@ -24,7 +24,9 @@ def process_inputs(inputs: dict[str, t.Any]) -> dict[str, t.Any]:
     A node UUID is indicated by the key ending with the suffix ``.uuid``.
 
     :param inputs: The inputs dictionary.
+    :type inputs: dict[str, t.Any]
     :returns: The deserialized inputs dictionary.
+    :rtype: dict[str, t.Any]
     """
     uuid_suffix = '.uuid'
     results = {}
@@ -61,7 +63,9 @@ class ProcessSubmitModel(pdt.BaseModel):
         """Process the inputs dictionary.
 
         :param inputs: The inputs to validate.
+        :type inputs: dict[str, t.Any]
         :returns: The validated inputs.
+        :rtype: dict[str, t.Any]
         """
         return process_inputs(inputs)
 

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -742,12 +742,12 @@ async def test_get_download_node(async_client: AsyncClient, array_data_node: orm
     The async client is needed to avoid an error caused by an I/O operation on closed file"""
 
     # Test that array is correctly downloaded as json
-    response = await async_client.get(f'/nodes/{array_data_node.pk}/download?download_format=json')
+    response = await async_client.get(f'/nodes/{array_data_node.pk}/download?format=json')
     assert response.status_code == 200, response.json()
     assert response.json().get('default', None) == array_data_node.get_array().tolist()
 
     # Test exception when wrong download format given
-    response = await async_client.get(f'/nodes/{array_data_node.pk}/download?download_format=cif')
+    response = await async_client.get(f'/nodes/{array_data_node.pk}/download?format=cif')
     assert response.status_code == 422, response.json()
     assert 'format cif is not supported' in response.json()['detail']
 


### PR DESCRIPTION
`/download?download_format=...` is redundant. Now `/download?format=`.

### Peripheral changes

There were a few docstring types missing. Added here.