### PR TITLE
Improve performance

### DIFF
--- a/aiida_restapi/routers/computers.py
+++ b/aiida_restapi/routers/computers.py
@@ -22,7 +22,7 @@ service = EntityService[orm.Computer, orm.Computer.Model](orm.Computer)
 
 @read_router.get(
     '/schema',
-    response_model=dict,
+    response_model=dict[str, t.Any],
     responses={
         422: {'model': errors.RequestValidationError},
     },
@@ -32,7 +32,7 @@ async def get_computers_schema(
         t.Literal['get', 'post'],
         Query(description='Type of schema to retrieve: "get" or "post"'),
     ] = 'get',
-) -> dict:
+) -> dict[str, t.Any]:
     """Get JSON schema for AiiDA computers."""
     return service.get_schema(which=which)
 
@@ -61,7 +61,7 @@ async def get_computers(
         query.QueryParams,
         Depends(query.query_params),
     ],
-) -> PaginatedResults[orm.Computer.Model]:
+) -> PaginatedResults[dict[str, t.Any]]:
     """Get AiiDA computers with optional filtering, sorting, and/or pagination."""
     return service.get_many(query_params)
 
@@ -78,7 +78,7 @@ async def get_computers(
     },
 )
 @with_dbenv()
-async def get_computer(pk: str) -> orm.Computer.Model:
+async def get_computer(pk: str) -> dict[str, t.Any]:
     """Get AiiDA computer by pk."""
     return service.get_one(pk)
 
@@ -112,6 +112,6 @@ async def get_computer_metadata(pk: str) -> dict[str, t.Any]:
 async def create_computer(
     computer_model: orm.Computer.CreateModel,
     current_user: t.Annotated[UserInDB, Depends(get_current_active_user)],
-) -> orm.Computer.Model:
+) -> dict[str, t.Any]:
     """Create new AiiDA computer."""
     return service.add_one(computer_model)

--- a/aiida_restapi/routers/groups.py
+++ b/aiida_restapi/routers/groups.py
@@ -22,7 +22,7 @@ service = EntityService[orm.Group, orm.Group.Model](orm.Group)
 
 @read_router.get(
     '/schema',
-    response_model=dict,
+    response_model=dict[str, t.Any],
     responses={
         422: {'model': errors.RequestValidationError},
     },
@@ -32,7 +32,7 @@ async def get_groups_schema(
         t.Literal['get', 'post'],
         Query(description='Type of schema to retrieve: "get" or "post"'),
     ] = 'get',
-) -> dict:
+) -> dict[str, t.Any]:
     """Get JSON schema for AiiDA groups."""
     return service.get_schema(which=which)
 
@@ -61,7 +61,7 @@ async def get_groups(
         query.QueryParams,
         Depends(query.query_params),
     ],
-) -> PaginatedResults[orm.Group.Model]:
+) -> PaginatedResults[dict[str, t.Any]]:
     """Get AiiDA groups with optional filtering, sorting, and/or pagination."""
     return service.get_many(query_params)
 
@@ -78,7 +78,7 @@ async def get_groups(
     },
 )
 @with_dbenv()
-async def get_group(uuid: str) -> orm.Group.Model:
+async def get_group(uuid: str) -> dict[str, t.Any]:
     """Get AiiDA group by uuid."""
     return service.get_one(uuid)
 
@@ -95,9 +95,9 @@ async def get_group(uuid: str) -> orm.Group.Model:
     },
 )
 @with_dbenv()
-async def get_group_user(uuid: str) -> orm.User.Model:
+async def get_group_user(uuid: str) -> dict[str, t.Any]:
     """Get the user associated with a group."""
-    return t.cast(orm.User.Model, service.get_related_one(uuid, orm.User))
+    return service.get_related_one(uuid, orm.User)
 
 
 @read_router.get(
@@ -118,7 +118,7 @@ async def get_group_nodes(
         query.QueryParams,
         Depends(query.query_params),
     ],
-) -> PaginatedResults[orm.Node.Model]:
+) -> PaginatedResults[dict[str, t.Any]]:
     """Get the nodes of a group."""
     return service.get_related_many(uuid, orm.Node, query_params)
 
@@ -152,6 +152,6 @@ async def get_group_extras(uuid: str) -> dict[str, t.Any]:
 async def create_group(
     group_model: orm.Group.CreateModel,
     current_user: t.Annotated[UserInDB, Depends(get_current_active_user)],
-) -> orm.Group.Model:
+) -> dict[str, t.Any]:
     """Create new AiiDA group."""
     return service.add_one(group_model)

--- a/aiida_restapi/routers/submit.py
+++ b/aiida_restapi/routers/submit.py
@@ -84,7 +84,7 @@ class ProcessSubmitModel(pdt.BaseModel):
 async def submit_process(
     process: ProcessSubmitModel,
     current_user: t.Annotated[UserInDB, Depends(get_current_active_user)],
-) -> orm.Node.Model:
+) -> dict[str, t.Any]:
     """Submit new AiiDA process."""
     try:
         entry_point_process = load_entry_point_from_string(process.entry_point)
@@ -94,4 +94,4 @@ async def submit_process(
         process_node = engine.submit(entry_point_process, **process.inputs)
     except Exception as exception:
         raise exceptions.InputValidationError(str(exception)) from exception
-    return t.cast(orm.Node.Model, process_node.to_model())
+    return process_node.serialize(minimal=True)

--- a/aiida_restapi/routers/users.py
+++ b/aiida_restapi/routers/users.py
@@ -22,7 +22,7 @@ service = EntityService[orm.User, orm.User.Model](orm.User)
 
 @read_router.get(
     '/schema',
-    response_model=dict,
+    response_model=dict[str, t.Any],
     responses={
         422: {'model': errors.RequestValidationError},
     },
@@ -32,7 +32,7 @@ async def get_users_schema(
         t.Literal['get', 'post'],
         Query(description='Type of schema to retrieve: "get" or "post"'),
     ] = 'get',
-) -> dict:
+) -> dict[str, t.Any]:
     """Get JSON schema for AiiDA users."""
     return service.get_schema(which=which)
 
@@ -61,7 +61,7 @@ async def get_users(
         query.QueryParams,
         Depends(query.query_params),
     ],
-) -> PaginatedResults[orm.User.Model]:
+) -> PaginatedResults[dict[str, t.Any]]:
     """Get AiiDA users with optional filtering, sorting, and/or pagination."""
     return service.get_many(query_params)
 
@@ -76,7 +76,7 @@ async def get_users(
     },
 )
 @with_dbenv()
-async def get_user(pk: int) -> orm.User.Model:
+async def get_user(pk: int) -> dict[str, t.Any]:
     """Get AiiDA user by pk."""
     return service.get_one(pk)
 
@@ -95,6 +95,6 @@ async def get_user(pk: int) -> orm.User.Model:
 async def create_user(
     user_model: orm.User.CreateModel,
     current_user: t.Annotated[UserInDB, Depends(get_current_active_user)],
-) -> orm.User.Model:
+) -> dict[str, t.Any]:
     """Create new AiiDA user."""
     return service.add_one(user_model)

--- a/aiida_restapi/services/entity.py
+++ b/aiida_restapi/services/entity.py
@@ -6,6 +6,7 @@ import typing as t
 
 from aiida import orm
 from aiida.common.exceptions import NotExistent
+from aiida.common.pydantic import get_metadata
 
 from aiida_restapi.common.exceptions import QueryBuilderException
 from aiida_restapi.common.pagination import PaginatedResults
@@ -25,13 +26,24 @@ class EntityService(t.Generic[EntityType, EntityModelType]):
         self.entity_class = entity_class
         self.with_key = entity_class.__name__.lower()
 
-    def get_schema(self, which: t.Literal['get', 'post'] | None = None) -> dict:
+    @property
+    def project(self) -> list[str]:
+        """Get the list of projections to use when querying the AiiDA entity.
+
+        :return: The list of projections to use when querying the AiiDA entity.
+        :rtype: list[str]
+        """
+        if not hasattr(self, '_project'):
+            self._project = self._get_projections()
+        return self._project
+
+    def get_schema(self, which: t.Literal['get', 'post'] | None = None) -> dict[str, t.Any]:
         """Get JSON schema for the AiiDA entity.
 
         :param which: The type of schema to retrieve: 'get' or 'post'.
         :type which: str | None
         :return: A dictionary with 'get' and 'post' keys containing the respective JSON schemas.
-        :rtype: dict
+        :rtype: dict[str, t.Any]
         :raises ValueError: If the 'which' parameter is not 'get' or 'post'.
         """
         if not which:
@@ -52,47 +64,51 @@ class EntityService(t.Generic[EntityType, EntityModelType]):
         """
         return self.entity_class.fields.keys()
 
-    def get_many(self, query_params: QueryParams) -> PaginatedResults[EntityModelType]:
+    def get_many(self, query_params: QueryParams) -> PaginatedResults[dict[str, t.Any]]:
         """Get AiiDA entities with optional filtering, sorting, and/or pagination.
 
         :param query_params: The query parameters, including filters, order_by, page_size, and page.
         :type query_params: QueryParams
-        :return: The paginated results, including total count, current page, page size, and list of entity models.
-        :rtype: PaginatedResults[EntityModelType]
+        :return: The paginated AiiDA entities.
+        :rtype: PaginatedResults[dict[str, t.Any]]
         """
         try:
             total = self.entity_class.collection.count(filters=query_params.filters)
-            results = self.entity_class.collection.find(
+            results = self.entity_class.collection.query(
                 filters=query_params.filters,
                 order_by=query_params.order_by,
                 limit=query_params.page_size,
                 offset=query_params.page_size * (query_params.page - 1),
-            )
+                project=self.project,
+            ).dict()
         except Exception as exception:
             raise QueryBuilderException(str(exception)) from exception
         return PaginatedResults(
             total=total,
             page=query_params.page,
             page_size=query_params.page_size,
-            data=[self._to_model(result) for result in results],
+            data=[next(iter(result.values())) for result in results],
         )
 
-    def get_one(self, identifier: str | int) -> EntityModelType:
+    def get_one(self, identifier: str | int) -> dict[str, t.Any]:
         """Get an AiiDA entity by id.
 
         :param identifier: The id of the entity to retrieve.
         :type identifier: str | int
-        :return: The AiiDA entity model, e.g. `orm.User.Model`, `orm.Node.Model`, etc.
-        :rtype: EntityModelType
+        :return: The AiiDA entity.
+        :rtype: dict[str, t.Any]
         """
-        entity = self.entity_class.collection.get(**{self.entity_class.identity_field: identifier})
-        return self._to_model(entity)
+        result = self.entity_class.collection.query(
+            filters={self.entity_class.identity_field: identifier},
+            project=self.project,
+        ).dict()
+        return next(iter(result[0].values()))
 
     def get_related_one(
         self,
         identifier: str | int,
         related_type: type[orm.Entity],
-    ) -> orm.Entity.Model:
+    ) -> dict[str, t.Any]:
         """Get a related foreign entity of an entity.
 
         :param identifier: The id of the entity to retrieve the foreign entity for.
@@ -100,7 +116,7 @@ class EntityService(t.Generic[EntityType, EntityModelType]):
         :param related_type: The related AiiDA ORM entity class to retrieve.
         :type related_type: type[orm.Entity]
         :return: The related foreign entity.
-        :rtype: EntityModelType
+        :rtype: dict[str, t.Any]
         """
         qb = (
             orm.QueryBuilder()
@@ -113,11 +129,12 @@ class EntityService(t.Generic[EntityType, EntityModelType]):
                 related_type,
                 joining_keyword=f'with_{self.with_key}',
                 joining_value='entity',
+                project=self._get_projections(related_type),
             )
         )
 
         try:
-            result = qb.first()
+            result = qb.dict()
         except Exception as exception:
             raise QueryBuilderException(str(exception)) from exception
 
@@ -126,14 +143,14 @@ class EntityService(t.Generic[EntityType, EntityModelType]):
                 f'{related_type.__name__} related to {self.entity_class.__name__}<{identifier}> not found.'
             )
 
-        return self._to_model(result[0])
+        return next(iter(result[0].values()))
 
     def get_related_many(
         self,
         identifier: str | int,
         related_type: type[orm.Entity],
         query_params: QueryParams,
-    ) -> PaginatedResults[orm.Entity.Model]:
+    ) -> PaginatedResults[dict[str, t.Any]]:
         """Get related foreign entities of an entity.
 
         :param identifier: The id of the entity to retrieve the foreign entities for.
@@ -143,7 +160,7 @@ class EntityService(t.Generic[EntityType, EntityModelType]):
         :param query_params: The query parameters, including filters, order_by, page_size, and page.
         :type query_params: QueryParams
         :return: The paginated results of related foreign entities.
-        :rtype: PaginatedResults[EntityModelType]
+        :rtype: PaginatedResults[dict[str, t.Any]]
         """
         qb = (
             orm.QueryBuilder(
@@ -160,15 +177,17 @@ class EntityService(t.Generic[EntityType, EntityModelType]):
                 joining_keyword=f'with_{self.with_key}',
                 joining_value='entity',
                 filters=query_params.filters,
+                project=self._get_projections(related_type),
+                tag='related',
             )
         )
 
-        order_by = {related_type: query_params.order_by} if query_params.order_by else {}
+        order_by = {'related': query_params.order_by} if query_params.order_by else {}
         qb.order_by([order_by])
 
         try:
             total = qb.count()
-            results = qb.all(flat=True)
+            results = qb.dict()
         except Exception as exception:
             raise QueryBuilderException(str(exception)) from exception
 
@@ -176,7 +195,7 @@ class EntityService(t.Generic[EntityType, EntityModelType]):
             total=total,
             page=query_params.page,
             page_size=query_params.page_size,
-            data=[self._to_model(result) for result in results],
+            data=[next(iter(result.values())) for result in results],
         )
 
     def get_field(self, identifier: str | int, field: str) -> t.Any:
@@ -204,23 +223,26 @@ class EntityService(t.Generic[EntityType, EntityModelType]):
 
         return result[0]
 
-    def add_one(self, model: EntityModelType) -> EntityModelType:
+    def add_one(self, model: EntityModelType) -> dict[str, t.Any]:
         """Create new AiiDA entity from its model.
 
         :param model: The Pydantic model of the entity to create.
         :type model: EntityModelType
         :return: The created and stored AiiDA `Entity` instance.
-        :rtype: EntityModelType
+        :rtype: dict[str, t.Any]
         """
         entity = self.entity_class.from_model(model).store()
-        return self._to_model(entity)
+        return entity.serialize(minimal=True)
 
-    def _to_model(self, entity: EntityType) -> EntityModelType:
-        """Convert an AiiDA entity to its Pydantic model.
+    def _get_projections(self, orm_class: type[orm.Entity] | None = None) -> list[str]:
+        """Get the list of projections to use when querying the AiiDA entity.
 
-        :param entity: The AiiDA entity to convert.
-        :type entity: EntityType
-        :return: The Pydantic model of the entity, excluding any fields specified in `excluded_fields`.
-        :rtype: EntityModelType
+        Exclude fields that may be large.
+
+        :param orm_class: The AiiDA ORM entity class to get the projections for.
+        :type orm_class: type[orm.Entity] | None
+        :return: The list of projections to use when querying the AiiDA entity.
+        :rtype: list[str]
         """
-        return t.cast(EntityModelType, entity.to_model(minimal=True))
+        orm_class = orm_class or self.entity_class
+        return [key for key, field in orm_class.Model.model_fields.items() if not get_metadata(field, 'may_be_large')]


### PR DESCRIPTION
This PR greatly improves fetching performance (10x) for `get_many` endpoints. It does so by avoiding the iterative serialization of node results, instead projecting on the fields which manual serialization would yield (predicatable). Validation is retained by way of FastAPIs `response_model`.

This PR implements a similar approach also for `get/add_one` endpoints, though in principle the performance boost here is negligible. It does so for consistency, though perhaps (to be discussed) we can retain the manual serialization for these endpoints. Note that for `add_one` endpoints, it is more convenient to retain it (already done in this PR).