### PR TITLE
Dont strip Entity identifier

### DIFF
--- a/aiida_restapi/jsonapi/hooks.py
+++ b/aiida_restapi/jsonapi/hooks.py
@@ -45,7 +45,7 @@ class BaseHook:
         for key, value in result.items():
             if key in cls.FOREIGN_FIELDS:
                 foreign_fields[key] = value
-            elif key != resource_identity:
+            else:
                 attributes[key] = value
         return identifier, attributes, foreign_fields
 

--- a/aiida_restapi/jsonapi/models/aiida.py
+++ b/aiida_restapi/jsonapi/models/aiida.py
@@ -12,8 +12,6 @@ def attributes_of(orm_class: type[orm.Entity]) -> type[Attributes]:
 
     fields = {}
     for key, field in orm_class.ReadModel.model_fields.items():
-        if key == orm_class.identity_field:
-            continue
         if get_metadata(field, 'may_be_large') or get_metadata(field, 'write_only'):
             continue
         try:

--- a/aiida_restapi/models/node.py
+++ b/aiida_restapi/models/node.py
@@ -121,7 +121,7 @@ MetadataType = t.Union[RepoFileMetadata, RepoDirMetadata]
 
 
 class NodeLink(pdt.BaseModel):
-    id: str = pdt.Field(
+    link_id: str = pdt.Field(
         description='The unique identifier of the link.',
         examples=['<source_uuid>:<target_uuid>'],
     )

--- a/aiida_restapi/routers/nodes.py
+++ b/aiida_restapi/routers/nodes.py
@@ -403,7 +403,7 @@ async def get_node_links(
     return JsonApi.collection(
         request,
         links,
-        resource_identity='id',
+        resource_identity='link_id',
         resource_type='links',
         query_params=query_params,
     )

--- a/aiida_restapi/routers/querybuilder.py
+++ b/aiida_restapi/routers/querybuilder.py
@@ -63,14 +63,14 @@ async def query_builder(
         parsed = [_to_resource_result(result, minimal=not full) for result in results]
 
     result = {
-        'id': 'qb-result',
+        'query_id': 'qb-result',
         'results': parsed,
     }
 
     return JsonApi.resource(
         request,
         result,
-        resource_identity='id',
+        resource_identity='query_id',
         resource_type='qb-results',
         meta={
             'total': total,

--- a/aiida_restapi/services/node.py
+++ b/aiida_restapi/services/node.py
@@ -201,7 +201,7 @@ class NodeService(EntityService[NodeType, NodeModelType]):
                 target_uuid = other_uuid
             data.append(
                 {
-                    'id': f'{source_uuid}:{target_uuid}',
+                    'link_id': f'{source_uuid}:{target_uuid}',
                     'source': source_uuid,
                     'target': target_uuid,
                     'link_label': link_label,

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -216,11 +216,11 @@ def test_get_node(client: TestClient, default_nodes: list[str | None]):
     assert response.status_code == 200, response.content
     node = response.json()['data']
     attributes = node['attributes']
-    assert 'uuid' not in attributes  # top-level id
     assert 'user' not in attributes  # relationship
     assert set(attributes.keys()) == {
         'pk',
         'node_type',
+        'uuid',
         'label',
         'description',
         'ctime',

--- a/tests/test_querybuilder.py
+++ b/tests/test_querybuilder.py
@@ -20,7 +20,7 @@ def test_querybuilder_all(client: TestClient):
             ],
         },
     )
-    assert response.status_code == 200
+    assert response.status_code == 200, response.text
     assert len(response.json()['data']['attributes']['results']) == 4
 
 
@@ -39,7 +39,7 @@ def test_querybuilder_full(client: TestClient):
             ],
         },
     )
-    assert response.status_code == 200
+    assert response.status_code == 200, response.text
     result = response.json()['data']['attributes']['results'][0]
     assert 'attributes' in result
     assert 'value' in result['attributes']
@@ -68,7 +68,7 @@ def test_querybuilder_flat(client: TestClient):
             },
         },
     )
-    assert response.status_code == 200
+    assert response.status_code == 200, response.text
     result = response.json()
     assert result['data']['attributes']['results'] == [1, 1.1]
 
@@ -111,6 +111,6 @@ def test_querybuilder_node_in_group(client: TestClient, default_nodes: list[str]
             },
         },
     )
-    assert response.status_code == 200
+    assert response.status_code == 200, response.text
     result = response.json()['data']['attributes']['results']
     assert result == [group.label, node.pk, node.value]


### PR DESCRIPTION
When building the JSON:API resource, we elevate the Entity identifier
to the JSON:API id field. In the original implementation, in addition to
elevating it, we also stripped it from the attributes. Here we simply
skip the stripping, accepting the duplication in favor of symmetry
with verdi output.

Closes #130 