### PR TITLE
Use ORM fetching + serialization for `get_one`

### DIFF
--- a/aiida_restapi/services/entity.py
+++ b/aiida_restapi/services/entity.py
@@ -69,21 +69,21 @@ class EntityService(t.Generic[EntityType, EntityModelType]):
 
         :param identifier: The id of the entity to retrieve.
         :type identifier: str | int
-        :return: The AiiDA entity.
+        :return: The serialized AiiDA entity.
         :rtype: dict[str, t.Any]
         """
-        result = self.entity_class.collection.query(
-            filters={self.entity_class.identity_field: identifier},
-            project=self.project,
-        ).dict()
-        return next(iter(result[0].values()))
+        try:
+            entity = self.entity_class.collection.get(**{self.entity_class.identity_field: identifier})
+        except NotExistent as exception:
+            raise NotExistent(f'{self.entity_class.__name__}<{identifier}> does not exist.') from exception
+        return entity.serialize(minimal=True)
 
     def get_many(self, query_params: QueryBuilderParams) -> PaginatedResults[dict[str, t.Any]]:
         """Get AiiDA entities with optional filtering, sorting, and/or pagination.
 
         :param query_params: The query parameters for filtering, sorting, and pagination.
         :type query_params: QueryBuilderParams
-        :return: The paginated results, including total count, current page, page size, and list of entity models.
+        :return: The paginated results, including total count, current page, page size, and list of serialized entities.
         :rtype: PaginatedResults[dict[str, t.Any]
         """
         try:


### PR DESCRIPTION
#112 makes an argument from consistency for using the `QueryBuilder`
also for fetching single entities (and implements it). However, as noted
in #112, it may be fine to keep it as is. #139 notes that at least the
current implementation of #112 for get_one is not safe and requires a
guard for null results. Here we simply follow the suggestion of #112
and revert this service method to using ORM fetching + serialization.
Though failed ORM fetching naturally raises `NonExistent` for null
results, resolving #139 in principle, we still wrap it in try/except
here to emit a clearer/more consistent error message.

Closes #139