### PR TITLE
Fix pagination

### DIFF
--- a/aiida_restapi/jsonapi/adapters.py
+++ b/aiida_restapi/jsonapi/adapters.py
@@ -215,17 +215,22 @@ class JsonApiAdapter:
             resources.append(resource)
             included.extend(included_items)
 
-        pagination = {
+        meta = {
             'total': results.total,
-            'page': query_params.page,
-            'page_size': query_params.page_size,
+            'page': results.page,
+            'page_size': results.page_size,
         } | (meta or {})
 
-        toplevel_links = cls._build_toplevel_links(request, **pagination)
+        toplevel_links = cls._build_toplevel_links(
+            request,
+            total=results.total,
+            page=query_params.page,
+            page_size=query_params.page_size,
+        )
 
         return {
             'links': toplevel_links,
-            'meta': pagination,
+            'meta': meta,
             'included': included or None,
             'data': resources,
         }

--- a/aiida_restapi/services/entity.py
+++ b/aiida_restapi/services/entity.py
@@ -84,7 +84,7 @@ class EntityService(t.Generic[EntityType, EntityModelType]):
         :param query_params: The query parameters for filtering, sorting, and pagination.
         :type query_params: QueryBuilderParams
         :return: The paginated results, including total count, current page, page size, and list of serialized entities.
-        :rtype: PaginatedResults[dict[str, t.Any]
+        :rtype: PaginatedResults
         """
         try:
             total = self.entity_class.collection.count(filters=query_params.filters)
@@ -100,7 +100,7 @@ class EntityService(t.Generic[EntityType, EntityModelType]):
         return PaginatedResults(
             total=total,
             page=query_params.page,
-            page_size=query_params.page_size,
+            page_size=len(results),
             data=[next(iter(result.values())) for result in results],
         )
 
@@ -160,7 +160,7 @@ class EntityService(t.Generic[EntityType, EntityModelType]):
         :param query_params: The query parameters, including filters, order_by, page_size, and page.
         :type query_params: QueryParams
         :return: The paginated results of related foreign entities.
-        :rtype: PaginatedResults[dict[str, t.Any]]
+        :rtype: PaginatedResults
         """
         qb = (
             orm.QueryBuilder(
@@ -194,7 +194,7 @@ class EntityService(t.Generic[EntityType, EntityModelType]):
         return PaginatedResults(
             total=total,
             page=query_params.page,
-            page_size=query_params.page_size,
+            page_size=len(results),
             data=[next(iter(result.values())) for result in results],
         )
 

--- a/aiida_restapi/services/node.py
+++ b/aiida_restapi/services/node.py
@@ -159,7 +159,7 @@ class NodeService(EntityService[NodeType, NodeModelType]):
         :param direction: Specify whether to retrieve incoming or outgoing links.
         :type direction: str
         :return: The paginated requested linked nodes.
-        :rtype: PaginatedResults[dict[str, t.Any]]
+        :rtype: PaginatedResults
         """
         qb = (
             orm.QueryBuilder(
@@ -186,7 +186,8 @@ class NodeService(EntityService[NodeType, NodeModelType]):
         qb.order_by([order_by])
 
         try:
-            total = qb.count()
+            node = self.entity_class.collection.get(uuid=uuid)
+            total = len(getattr(node.base.links, f'get_{direction}')().all())
             results = qb.all()
         except Exception as exception:
             raise QueryBuilderException(str(exception)) from exception
@@ -212,7 +213,7 @@ class NodeService(EntityService[NodeType, NodeModelType]):
         return PaginatedResults(
             total=total,
             page=query_params.page,
-            page_size=query_params.page_size,
+            page_size=len(data),
             data=data,
         )
 


### PR DESCRIPTION
The pagination system had a couple of bugs:
1. Pagination metadata was incorrectly referencing the query parameters rather than the actual results
2. Link pagination was applied after the filters, leading to incorrect total counts

Both are resolved here.