### PR TITLE
Return QB results in dict format

### DIFF
--- a/aiida_restapi/routers/querybuilder.py
+++ b/aiida_restapi/routers/querybuilder.py
@@ -42,8 +42,8 @@ async def query_builder(
     """Execute a QueryBuilder query based on the provided dictionary."""
     query_dict = query.model_dump()
 
-    limit = query_dict.pop('limit', 10)
-    offset = query_dict.get('offset', 0)
+    limit = query_dict.pop('limit', 10) or 1
+    offset = query_dict.get('offset', 0) or 0
 
     try:
         qb = orm.QueryBuilder.from_dict(query_dict)

--- a/aiida_restapi/routers/querybuilder.py
+++ b/aiida_restapi/routers/querybuilder.py
@@ -34,10 +34,6 @@ read_router = APIRouter(prefix='/querybuilder')
 async def query_builder(
     request: Request,
     query: QueryBuilderDict,
-    flat: t.Annotated[
-        bool,
-        Query(description='Whether to return results flat.'),
-    ] = False,
     full: t.Annotated[
         bool,
         Query(description='Whether to return full results (minimal=False).'),
@@ -53,23 +49,21 @@ async def query_builder(
         qb = orm.QueryBuilder.from_dict(query_dict)
         total = qb.count()
         qb.limit(limit)
-        results = qb.all(flat=flat)
+        results = qb.dict()
     except Exception as exception:
         raise QueryBuilderException(str(exception)) from exception
 
-    if flat:
-        parsed = _to_resource_result(results, minimal=not full)
-    else:
-        parsed = [_to_resource_result(result, minimal=not full) for result in results]
-
-    result = {
-        'query_id': 'qb-result',
-        'results': parsed,
-    }
+    try:
+        normalized_results = {
+            'query_id': 'qb-result',
+            'results': [normalize_result(result, minimal=not full) for result in results],
+        }
+    except Exception as exception:
+        raise QueryBuilderException(str(exception)) from exception
 
     return JsonApi.resource(
         request,
-        result,
+        normalized_results,
         resource_identity='query_id',
         resource_type='qb-results',
         meta={
@@ -80,20 +74,42 @@ async def query_builder(
     )
 
 
-def _to_resource_result(raw: list[t.Any], minimal: bool = True) -> list[t.Any]:
-    """Convert raw QueryBuilder results to JSON:API serializable format.
+ALIAS_MAP = {
+    'id': 'pk',
+    'dbcomputer_id': 'computer',
+    'user_id': 'user',
+    'dbnode_id': 'node',
+}
 
-    :param raw: The raw results from QueryBuilder.
-    :type raw: list[t.Any]
+
+def normalize_result(
+    result: dict[str, dict[str, t.Any]],
+    minimal: bool = True,
+) -> dict[str, dict[str, t.Any]]:
+    """Serialize any entities in the QueryBuilder result.
+
+    If the result only contains a single projection of the entity, it will be serialized flat.
+    Otherwise, the projections will be normalized, serializing any entities under the '*' key
+    and mapping DB keys to their public aliases (e.g. 'id' -> 'pk').
+
+    :param result: The QueryBuilder result.
+    :type result: dict[str, dict[str, t.Any]]
     :param minimal: Whether to serialize entities in minimal form.
     :type minimal: bool
-    :return: The parsed results.
-    :rtype: list[t.Any]
+    :return: The parsed result.
+    :rtype: dict[str, dict[str, t.Any]]
     """
-    parsed: list[t.Any] = []
-    for item in raw:
-        if isinstance(item, orm.Entity):
-            parsed.append(item.serialize(minimal=minimal))
-        else:
-            parsed.append(item)
-    return parsed
+    for tag, projections in result.items():
+        if len(projections) == 1 and '*' in projections:
+            result[tag] = projections['*'].serialize(minimal=minimal)
+            break
+
+        normalized: dict[str, dict[str, t.Any]] = {}
+        for key, projection in projections.items():
+            if key == '*':
+                normalized[key] = projection.serialize(minimal=minimal)
+            else:
+                normalized[ALIAS_MAP.get(key, key)] = projection
+        result[tag] = normalized
+
+    return result

--- a/aiida_restapi/routers/querybuilder.py
+++ b/aiida_restapi/routers/querybuilder.py
@@ -102,7 +102,7 @@ def normalize_result(
     for tag, projections in result.items():
         if len(projections) == 1 and '*' in projections:
             result[tag] = projections['*'].serialize(minimal=minimal)
-            break
+            continue
 
         normalized: dict[str, dict[str, t.Any]] = {}
         for key, projection in projections.items():

--- a/tests/test_querybuilder.py
+++ b/tests/test_querybuilder.py
@@ -40,37 +40,12 @@ def test_querybuilder_full(client: TestClient):
         },
     )
     assert response.status_code == 200, response.text
-    result = response.json()['data']['attributes']['results'][0]
+    result = response.json()['data']['attributes']['results'][0]['integer']
     assert 'attributes' in result
     assert 'value' in result['attributes']
     assert result['attributes']['value'] == 1
     assert 'extras' in result
     assert 'repository_metadata' in result
-
-
-@pytest.mark.usefixtures('default_nodes')
-def test_querybuilder_flat(client: TestClient):
-    """Test QueryBuilder result with flat response."""
-    response = client.post(
-        '/querybuilder?flat=true',
-        json={
-            'path': [
-                {
-                    'entity_type': ['data.core.int.Int.', 'data.core.float.Float.'],
-                    'orm_base': 'node',
-                    'tag': 'nodes',
-                },
-            ],
-            'project': {
-                'nodes': [
-                    'attributes.value',
-                ],
-            },
-        },
-    )
-    assert response.status_code == 200, response.text
-    result = response.json()
-    assert result['data']['attributes']['results'] == [1, 1.1]
 
 
 def test_querybuilder_node_in_group(client: TestClient, default_nodes: list[str], default_groups: list[str]):
@@ -113,4 +88,14 @@ def test_querybuilder_node_in_group(client: TestClient, default_nodes: list[str]
     )
     assert response.status_code == 200, response.text
     result = response.json()['data']['attributes']['results']
-    assert result == [group.label, node.pk, node.value]
+    assert result == [
+        {
+            'group': {
+                'label': group.label,
+            },
+            'node': {
+                'pk': node.pk,
+                'attributes.value': node.value,
+            },
+        }
+    ]

--- a/tests/test_querybuilder.py
+++ b/tests/test_querybuilder.py
@@ -99,3 +99,72 @@ def test_querybuilder_node_in_group(client: TestClient, default_nodes: list[str]
             },
         }
     ]
+
+
+def _format_time(time: str) -> str:
+    """Format a time string to ISO 8601 format with 'Z' suffix for UTC."""
+    return time.isoformat().replace('+00:00', 'Z')
+
+
+def test_querybuilder_result_normalization(client: TestClient, default_nodes: list[str], default_groups: list[str]):
+    """Test the normalization of QueryBuilder results."""
+    node = orm.load_node(default_nodes[0])
+    group = orm.load_group(default_groups[0])
+    group.add_nodes(node)
+    response = client.post(
+        '/querybuilder?flat=true',
+        json={
+            'path': [
+                {
+                    'entity_type': 'group.core.',
+                    'orm_base': 'group',
+                    'tag': 'group',
+                },
+                {
+                    'entity_type': 'data.core.int.Int.',
+                    'orm_base': 'node',
+                    'joining_keyword': 'with_group',
+                    'joining_value': 'group',
+                    'tag': 'node',
+                },
+            ],
+            'filters': {
+                'group': {
+                    'pk': group.pk,
+                }
+            },
+            'project': {
+                'group': [
+                    '*',
+                ],
+                'node': [
+                    '*',
+                ],
+            },
+        },
+    )
+    assert response.status_code == 200, response.text
+    result = response.json()['data']['attributes']['results']
+    assert result == [
+        {
+            'group': {
+                'pk': group.pk,
+                'uuid': str(group.uuid),
+                'type_string': group.type_string,
+                'label': group.label,
+                'description': group.description,
+                'time': _format_time(group.time),
+                'user': group.user.id,
+            },
+            'node': {
+                'pk': node.pk,
+                'uuid': str(node.uuid),
+                'node_type': node.node_type,
+                'label': node.label,
+                'description': node.description,
+                'ctime': _format_time(node.ctime),
+                'mtime': _format_time(node.mtime),
+                'user': node.user.id,
+            },
+        }
+    ]


### PR DESCRIPTION
`QueryBuilder().dict()` returns a more general result form that is easier to work with, particularly as it returns projection field keys along with values.