### PR TITLE
Add root path support and improve test handling

### DIFF
--- a/aiida_restapi/cli/main.py
+++ b/aiida_restapi/cli/main.py
@@ -36,6 +36,7 @@ def start(
     :type port: int
     """
 
+    os.environ['AIIDA_RESTAPI_ROOT_PATH'] = root_path
     os.environ['AIIDA_RESTAPI_READ_ONLY'] = '1' if read_only else '0'
 
     click.echo(f'Starting REST API (read_only={read_only}, watch={watch}) on {host}:{port}')

--- a/aiida_restapi/cli/main.py
+++ b/aiida_restapi/cli/main.py
@@ -10,13 +10,22 @@ def cli() -> None:
 
 
 @cli.command()
+@click.option('--root-path', default='', show_default=True, help='The root path to mount the API under.')
 @click.option('--host', default='127.0.0.1', show_default=True)
 @click.option('--port', default=8000, show_default=True, type=int)
 @click.option('--read-only', is_flag=True)
 @click.option('--watch', is_flag=True)
-def start(read_only: bool, watch: bool, host: str, port: int) -> None:
+def start(
+    root_path: str,
+    read_only: bool,
+    watch: bool,
+    host: str,
+    port: int,
+) -> None:
     """Start the AiiDA REST API service.
 
+    :param root_path: The root path to mount the API under.
+    :type root_path: str
     :param read_only: If set, the API will be started in read-only mode.
     :type read_only: bool
     :param watch: If set, the API will watch for code changes and reload automatically.
@@ -33,6 +42,7 @@ def start(read_only: bool, watch: bool, host: str, port: int) -> None:
 
     uvicorn.run(
         'aiida_restapi.main:create_app',
+        root_path=root_path,
         host=host,
         port=port,
         reload=watch,

--- a/aiida_restapi/config.py
+++ b/aiida_restapi/config.py
@@ -21,6 +21,7 @@ fake_users_db = {
     }
 }
 
+
 API_CONFIG = {
     'PREFIX': '/v0',
     'VERSION': __version__,

--- a/aiida_restapi/jsonapi/adapters.py
+++ b/aiida_restapi/jsonapi/adapters.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import typing as t
 
 from aiida import orm
-from fastapi.datastructures import URL
 from starlette.requests import Request
 
 from aiida_restapi.common.pagination import PaginatedResults
@@ -33,8 +32,6 @@ class JsonApiAdapter:
         'nodes': hooks.NodeHook,
         'links': hooks.LinkHook,
     }
-
-    BASE_API_URL = ''
 
     @classmethod
     def register_hooks(cls, new_hooks: dict[str, type[hooks.BaseHook]]) -> None:
@@ -73,19 +70,16 @@ class JsonApiAdapter:
         :return: The JSON:API document.
         :rtype: JsonApiResponse
         """
-        base_api = cls._base_api_url(request)
-
         resource, included = cls._build_resource(
             result,
             resource_identity,
             resource_type,
-            base_api,
             include=include,
         )
 
         return {
             'links': {
-                'self': str(request.url),
+                'self': str(request.url).replace(str(request.base_url), '/'),
             },
             'data': resource,
             'included': included or None,
@@ -123,8 +117,6 @@ class JsonApiAdapter:
         :return: The JSON:API document.
         :rtype: JsonApiResponse
         """
-        base_api = cls._base_api_url(request)
-
         hook = cls._hook_for(parent_type)
 
         included = (
@@ -134,7 +126,6 @@ class JsonApiAdapter:
                     included_attributes,
                     included_foreign_fields,
                     included_type,
-                    base_api,
                 )
                 for (
                     included_identifier,
@@ -155,7 +146,6 @@ class JsonApiAdapter:
             pid=pid,
             parent_type=parent_type,
             child_type=child_type,
-            base_api=base_api,
         )
 
         return {
@@ -196,8 +186,6 @@ class JsonApiAdapter:
         :rtype: JsonApiResponse
         """
 
-        base_api = cls._base_api_url(request)
-
         resources: list[dict[str, t.Any]] = []
         included: list[dict[str, t.Any]] = []
 
@@ -208,7 +196,6 @@ class JsonApiAdapter:
                 result,
                 resource_identity,
                 resource_type,
-                base_api,
                 include=query_params.include,
                 cache=included_cache,
             )
@@ -236,26 +223,11 @@ class JsonApiAdapter:
         }
 
     @classmethod
-    def _base_api_url(cls, request: Request) -> str:
-        """Return the base API URL from the request.
-
-        :param request: The incoming request.
-        :type request: Request
-        :return: The base API URL.
-        :rtype: str
-        """
-        if not cls.BASE_API_URL:
-            base = str(request.base_url).rstrip('/')
-            cls.BASE_API_URL = f'{base}/{API_CONFIG["PREFIX"].lstrip("/")}'
-        return cls.BASE_API_URL
-
-    @classmethod
     def _build_resource(
         cls,
         result: dict[str, t.Any],
         resource_identity: str,
         resource_type: str,
-        base_api: str,
         include: list[str] | None = None,
         cache: IncludedItemParamsCache | None = None,
     ) -> tuple[dict[str, t.Any], list[dict[str, t.Any]]]:
@@ -266,8 +238,6 @@ class JsonApiAdapter:
         :type resource_identity: str
         :param resource_type: The resource type to use for the resource.
         :type resource_type: str
-        :param base_api: The base API URL.
-        :type base_api: str
         :param include: A list of related resource types to include.
         :type include: list[str] | None
         :param cache: An optional cache for included resources.
@@ -291,7 +261,6 @@ class JsonApiAdapter:
                     included_attributes,
                     included_foreign_fields,
                     included_type,
-                    base_api,
                 )
                 for (
                     included_identifier,
@@ -313,7 +282,6 @@ class JsonApiAdapter:
             attributes,
             foreign_fields,
             resource_type,
-            base_api,
         )
 
         return resource, included
@@ -336,14 +304,11 @@ class JsonApiAdapter:
         attributes: dict[str, t.Any],
         foreign_fields: dict[str, t.Any],
         resource_type: str,
-        base_api: str,
     ) -> dict[str, t.Any]:
         """Convert an AiiDA quantity to a JSON:API resource.
 
         :param result: The result dictionary to convert.
         :type result: dict[str, t.Any]
-        :param base_api: The base API URL.
-        :type base_api: str
         :param resource_identity: The identity field to use for the resource.
         :type resource_identity: str
         :param resource_type: The resource type to use for the resource.
@@ -355,14 +320,12 @@ class JsonApiAdapter:
 
         links = hook.links(
             resource_type=resource_type,
-            base_api_url=base_api,
             url_id=str(identifier),
         )
 
         relationships = hook.relationships(
             foreign_fields=foreign_fields,
             resource_type=resource_type,
-            base_api_url=base_api,
             url_id=str(identifier),
         )
 
@@ -382,7 +345,6 @@ class JsonApiAdapter:
         pid: str | int,
         parent_type: str,
         child_type: str,
-        base_api: str,
     ) -> dict[str, t.Any]:
         """Convert an dependent quantity to a single resource JSON:API document.
 
@@ -394,12 +356,10 @@ class JsonApiAdapter:
         :type parent_type: str
         :param child_type: The child resource type.
         :type child_type: str
-        :param base_api: The base API URL.
-        :type base_api: str
         :return: The JSON:API resource object.
         :rtype: dict[str, t.Any]
         """
-        root = f'{base_api}/{parent_type}'
+        root = f'{API_CONFIG["PREFIX"]}/{parent_type}'
 
         return {
             'id': pid,
@@ -447,28 +407,28 @@ class JsonApiAdapter:
         links: dict[str, str] = {'self': str(current)}
 
         if page > 1:
-            links['prev'] = str(cls._build_link(request, page=page - 1, page_size=page_size))
-            links['first'] = str(cls._build_link(request, page=1, page_size=page_size))
+            links['prev'] = cls._build_link(request, page=page - 1, page_size=page_size)
+            links['first'] = cls._build_link(request, page=1, page_size=page_size)
 
         last_page = (total + page_size - 1) // page_size if page_size > 0 else 1
         if last_page >= 1:
-            links['last'] = str(cls._build_link(request, page=last_page, page_size=page_size))
+            links['last'] = cls._build_link(request, page=last_page, page_size=page_size)
 
         if page < last_page:
-            links['next'] = str(cls._build_link(request, page=page + 1, page_size=page_size))
+            links['next'] = cls._build_link(request, page=page + 1, page_size=page_size)
 
         return links
 
     @staticmethod
-    def _build_link(request: Request, **updates: str | int | None) -> URL:
-        """Return a URL with updated query parameters.
+    def _build_link(request: Request, **updates: dict[str, str | int | None]) -> str:
+        """Return a relative URL with updated query parameters.
 
         :param request: The incoming request.
         :type request: Request
         :param updates: The query parameter updates.
         :type updates: dict[str, str | int | None]
-        :return: The updated URL.
-        :rtype: URL
+        :return: The updated URL relative to the base URL.
+        :rtype: str
         """
         url = request.url
         q = dict(request.query_params)
@@ -479,4 +439,5 @@ class JsonApiAdapter:
             else:
                 q[k] = str(v)
 
-        return url.replace_query_params(**q)
+        url = url.replace_query_params(**q)
+        return str(url).replace(str(request.base_url), '/')

--- a/aiida_restapi/jsonapi/adapters.py
+++ b/aiida_restapi/jsonapi/adapters.py
@@ -446,7 +446,6 @@ class JsonApiAdapter:
         :return: The updated URL relative to the base URL.
         :rtype: str
         """
-        url = request.url
         q = deepcopy(dict(request.query_params))
 
         for k, v in updates.items():
@@ -455,7 +454,7 @@ class JsonApiAdapter:
             else:
                 q[k] = str(v)
 
-        url = url.replace_query_params(**q)
+        url = request.url.replace_query_params(**q)
 
         link = url.path
         if url.query:

--- a/aiida_restapi/jsonapi/adapters.py
+++ b/aiida_restapi/jsonapi/adapters.py
@@ -436,23 +436,24 @@ class JsonApiAdapter:
         return links
 
     @staticmethod
-    def _build_link(request: Request, **updates: dict[str, str | int | None]) -> str:
+    def _build_link(request: Request, page: int | None = None, page_size: int | None = None) -> str:
         """Return a relative URL with updated query parameters.
 
         :param request: The incoming request.
         :type request: Request
-        :param updates: The query parameter updates.
-        :type updates: dict[str, str | int | None]
+        :param page: The current page.
+        :type page: int | None
+        :param page_size: The page size.
+        :type page_size: int | None
         :return: The updated URL relative to the base URL.
         :rtype: str
         """
         q = deepcopy(dict(request.query_params))
 
-        for k, v in updates.items():
-            if v is None:
-                q.pop(k, None)
-            else:
-                q[k] = str(v)
+        if page is not None:
+            q['page'] = str(page)
+        if page_size is not None:
+            q['page_size'] = str(page_size)
 
         url = request.url.replace_query_params(**q)
 

--- a/aiida_restapi/jsonapi/adapters.py
+++ b/aiida_restapi/jsonapi/adapters.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import typing as t
+from copy import deepcopy
 
 from aiida import orm
 from starlette.requests import Request
@@ -71,15 +72,16 @@ class JsonApiAdapter:
         :rtype: JsonApiResponse
         """
         resource, included = cls._build_resource(
+            request,
             result,
             resource_identity,
             resource_type,
-            include=include,
+            include,
         )
 
         return {
             'links': {
-                'self': str(request.url).replace(str(request.base_url), '/'),
+                'self': cls._build_link(request),
             },
             'data': resource,
             'included': included or None,
@@ -122,6 +124,7 @@ class JsonApiAdapter:
         included = (
             [
                 cls._to_resource(
+                    request,
                     included_identifier,
                     included_attributes,
                     included_foreign_fields,
@@ -142,15 +145,16 @@ class JsonApiAdapter:
         )
 
         child_resource = cls._to_child_resource(
+            request,
             result,
-            pid=pid,
-            parent_type=parent_type,
-            child_type=child_type,
+            pid,
+            parent_type,
+            child_type,
         )
 
         return {
             'links': {
-                'self': str(request.url),
+                'self': cls._build_link(request),
             },
             'data': child_resource,
             'included': included or None,
@@ -193,11 +197,12 @@ class JsonApiAdapter:
 
         for result in results.data:
             resource, included_items = cls._build_resource(
+                request,
                 result,
                 resource_identity,
                 resource_type,
-                include=query_params.include,
-                cache=included_cache,
+                query_params.include,
+                included_cache,
             )
             resources.append(resource)
             included.extend(included_items)
@@ -210,9 +215,9 @@ class JsonApiAdapter:
 
         toplevel_links = cls._build_toplevel_links(
             request,
-            total=results.total,
-            page=query_params.page,
-            page_size=query_params.page_size,
+            results.total,
+            query_params.page,
+            query_params.page_size,
         )
 
         return {
@@ -225,6 +230,7 @@ class JsonApiAdapter:
     @classmethod
     def _build_resource(
         cls,
+        request: Request,
         result: dict[str, t.Any],
         resource_identity: str,
         resource_type: str,
@@ -232,6 +238,9 @@ class JsonApiAdapter:
         cache: IncludedItemParamsCache | None = None,
     ) -> tuple[dict[str, t.Any], list[dict[str, t.Any]]]:
         """Build a JSON:API resource and its included related resources.
+
+        :param request: The incoming request.
+        :type request: Request
         :param result: The result to convert.
         :type result: dict[str, t.Any]
         :param resource_identity: The identity field to use for the resource.
@@ -257,6 +266,7 @@ class JsonApiAdapter:
         included = (
             [
                 cls._to_resource(
+                    request,
                     included_identifier,
                     included_attributes,
                     included_foreign_fields,
@@ -278,6 +288,7 @@ class JsonApiAdapter:
         )
 
         resource = cls._to_resource(
+            request,
             identifier,
             attributes,
             foreign_fields,
@@ -300,6 +311,7 @@ class JsonApiAdapter:
     @classmethod
     def _to_resource(
         cls,
+        request: Request,
         identifier: str | int,
         attributes: dict[str, t.Any],
         foreign_fields: dict[str, t.Any],
@@ -307,8 +319,8 @@ class JsonApiAdapter:
     ) -> dict[str, t.Any]:
         """Convert an AiiDA quantity to a JSON:API resource.
 
-        :param result: The result dictionary to convert.
-        :type result: dict[str, t.Any]
+        :param request: The incoming request.
+        :type request: Request
         :param resource_identity: The identity field to use for the resource.
         :type resource_identity: str
         :param resource_type: The resource type to use for the resource.
@@ -319,11 +331,13 @@ class JsonApiAdapter:
         hook = cls._hook_for(resource_type)
 
         links = hook.links(
+            request,
             resource_type=resource_type,
             url_id=str(identifier),
         )
 
         relationships = hook.relationships(
+            request,
             foreign_fields=foreign_fields,
             resource_type=resource_type,
             url_id=str(identifier),
@@ -340,14 +354,16 @@ class JsonApiAdapter:
     @classmethod
     def _to_child_resource(
         cls,
+        request: Request,
         result: dict[str, t.Any],
-        *,
         pid: str | int,
         parent_type: str,
         child_type: str,
     ) -> dict[str, t.Any]:
-        """Convert an dependent quantity to a single resource JSON:API document.
+        """Convert a dependent quantity to a single resource JSON:API document.
 
+        :param request: The incoming request.
+        :type request: Request
         :param result: The result dictionary to convert.
         :type result: dict[str, t.Any]
         :param pid: The parent resource identifier.
@@ -359,7 +375,7 @@ class JsonApiAdapter:
         :return: The JSON:API resource object.
         :rtype: dict[str, t.Any]
         """
-        root = f'{API_CONFIG["PREFIX"]}/{parent_type}'
+        root = f'{request.scope["root_path"]}{API_CONFIG["PREFIX"]}/{parent_type}'
 
         return {
             'id': pid,
@@ -385,20 +401,20 @@ class JsonApiAdapter:
     def _build_toplevel_links(
         cls,
         request: Request,
-        page_size: int,
-        page: int,
         total: int,
+        page: int,
+        page_size: int,
     ) -> dict[str, str]:
         """Return dict suitable for JSON:API top-level links (self/next/prev/first/last).
 
         :param request: The incoming request.
         :type request: Request
-        :param page_size: The page size.
-        :type page_size: int
-        :param page: The current page.
-        :type page: int
         :param total: The total number of items.
         :type total: int
+        :param page: The current page.
+        :type page: int
+        :param page_size: The page size.
+        :type page_size: int
         :return: The top-level links.
         :rtype: dict[str, str]
         """
@@ -431,7 +447,7 @@ class JsonApiAdapter:
         :rtype: str
         """
         url = request.url
-        q = dict(request.query_params)
+        q = deepcopy(dict(request.query_params))
 
         for k, v in updates.items():
             if v is None:
@@ -440,4 +456,9 @@ class JsonApiAdapter:
                 q[k] = str(v)
 
         url = url.replace_query_params(**q)
-        return str(url).replace(str(request.base_url), '/')
+
+        link = url.path
+        if url.query:
+            link += f'?{url.query}'
+
+        return link

--- a/aiida_restapi/jsonapi/hooks.py
+++ b/aiida_restapi/jsonapi/hooks.py
@@ -6,8 +6,6 @@ from aiida import orm
 from aiida.common.exceptions import NotExistent
 from fastapi import Request
 
-from aiida_restapi.config import API_CONFIG
-
 from .utils import IncludedItemParamsCache
 
 IncludedItemParams = tuple[t.Union[str, int], str, dict[str, t.Any], dict[str, t.Any]]
@@ -177,9 +175,9 @@ class ResourceHook(BaseHook):
         resource_type: str,
         url_id: str,
     ) -> dict[str, str | dict[str, t.Any]]:
-        relative_path = request.scope['root_path'] + API_CONFIG['PREFIX']
+        api_path = request.app.state.api_path
         return {
-            'self': f'{relative_path}/{resource_type}/{url_id}',
+            'self': f'{api_path}/{resource_type}/{url_id}',
         }
 
     @classmethod
@@ -191,11 +189,11 @@ class ResourceHook(BaseHook):
         resource_type: str,
         url_id: str,
     ) -> dict[str, dict[str, t.Any]]:
-        relative_path = request.scope['root_path'] + API_CONFIG['PREFIX']
+        api_path = request.app.state.api_path
         return {
             'collection': {
                 'links': {
-                    'related': f'{relative_path}/{resource_type}',
+                    'related': f'{api_path}/{resource_type}',
                 }
             }
         }
@@ -231,11 +229,11 @@ class ComputerHook(EntityHook):
         resource_type: str,
         url_id: str,
     ) -> dict[str, dict[str, t.Any]]:
-        relative_path = request.scope['root_path'] + API_CONFIG['PREFIX']
+        api_path = request.app.state.api_path
         extra = {
             'metadata': {
                 'links': {
-                    'related': f'{relative_path}/{resource_type}/{url_id}/metadata',
+                    'related': f'{api_path}/{resource_type}/{url_id}/metadata',
                 }
             },
         }
@@ -264,11 +262,11 @@ class GroupHook(EntityHook):
         resource_type: str,
         url_id: str,
     ) -> dict[str, dict[str, t.Any]]:
-        relative_path = request.scope['root_path'] + API_CONFIG['PREFIX']
+        api_path = request.app.state.api_path
         extra = {
             'user': {
                 'links': {
-                    'related': f'{relative_path}/{resource_type}/{url_id}/user',
+                    'related': f'{api_path}/{resource_type}/{url_id}/user',
                 },
                 'data': {
                     'id': str(foreign_fields.get('user')),
@@ -277,12 +275,12 @@ class GroupHook(EntityHook):
             },
             'nodes': {
                 'links': {
-                    'related': f'{relative_path}/{resource_type}/{url_id}/nodes',
+                    'related': f'{api_path}/{resource_type}/{url_id}/nodes',
                 }
             },
             'extras': {
                 'links': {
-                    'related': f'{relative_path}/{resource_type}/{url_id}/extras',
+                    'related': f'{api_path}/{resource_type}/{url_id}/extras',
                 }
             },
         }
@@ -311,11 +309,11 @@ class NodeHook(EntityHook):
         resource_type: str,
         url_id: str,
     ) -> dict[str, dict[str, t.Any]]:
-        relative_path = request.scope['root_path'] + API_CONFIG['PREFIX']
+        api_path = request.app.state.api_path
         extra = {
             'user': {
                 'links': {
-                    'related': f'{relative_path}/{resource_type}/{url_id}/user',
+                    'related': f'{api_path}/{resource_type}/{url_id}/user',
                 },
                 'data': {
                     'id': str(foreign_fields.get('user')),
@@ -329,7 +327,7 @@ class NodeHook(EntityHook):
         if computer_id is not None:
             extra['computer'] = {
                 'links': {
-                    'related': f'{relative_path}/{resource_type}/{url_id}/computer',
+                    'related': f'{api_path}/{resource_type}/{url_id}/computer',
                 },
                 'data': {
                     'id': str(computer_id),
@@ -340,32 +338,32 @@ class NodeHook(EntityHook):
         extra |= {
             'groups': {
                 'links': {
-                    'related': f'{relative_path}/{resource_type}/{url_id}/groups',
+                    'related': f'{api_path}/{resource_type}/{url_id}/groups',
                 }
             },
             'attributes': {
                 'links': {
-                    'related': f'{relative_path}/{resource_type}/{url_id}/attributes',
+                    'related': f'{api_path}/{resource_type}/{url_id}/attributes',
                 }
             },
             'extras': {
                 'links': {
-                    'related': f'{relative_path}/{resource_type}/{url_id}/extras',
+                    'related': f'{api_path}/{resource_type}/{url_id}/extras',
                 }
             },
             'repository_metadata': {
                 'links': {
-                    'related': f'{relative_path}/{resource_type}/{url_id}/repo/metadata',
+                    'related': f'{api_path}/{resource_type}/{url_id}/repo/metadata',
                 }
             },
             'incoming': {
                 'links': {
-                    'related': f'{relative_path}/{resource_type}/{url_id}/links?direction=incoming',
+                    'related': f'{api_path}/{resource_type}/{url_id}/links?direction=incoming',
                 }
             },
             'outgoing': {
                 'links': {
-                    'related': f'{relative_path}/{resource_type}/{url_id}/links?direction=outgoing',
+                    'related': f'{api_path}/{resource_type}/{url_id}/links?direction=outgoing',
                 }
             },
         }
@@ -400,12 +398,12 @@ class LinkHook(BaseHook):
         resource_type: str,
         url_id: str,
     ) -> dict[str, dict[str, t.Any]]:
-        relative_path = request.scope['root_path'] + API_CONFIG['PREFIX']
+        api_path = request.app.state.api_path
         extra = {}
         if source := foreign_fields.get('source', None):
             extra['source'] = {
                 'links': {
-                    'related': f'{relative_path}/nodes/{source}',
+                    'related': f'{api_path}/nodes/{source}',
                 },
                 'data': {
                     'id': str(source),
@@ -415,7 +413,7 @@ class LinkHook(BaseHook):
         if target := foreign_fields.get('target', None):
             extra['target'] = {
                 'links': {
-                    'related': f'{relative_path}/nodes/{target}',
+                    'related': f'{api_path}/nodes/{target}',
                 },
                 'data': {
                     'id': str(target),

--- a/aiida_restapi/jsonapi/hooks.py
+++ b/aiida_restapi/jsonapi/hooks.py
@@ -5,6 +5,8 @@ import typing as t
 from aiida import orm
 from aiida.common.exceptions import NotExistent
 
+from aiida_restapi.config import API_CONFIG
+
 from .utils import IncludedItemParamsCache
 
 IncludedItemParams = tuple[t.Union[str, int], str, dict[str, t.Any], dict[str, t.Any]]
@@ -54,15 +56,12 @@ class BaseHook:
         cls,
         *,
         resource_type: str,
-        base_api_url: str,
         url_id: str,
     ) -> dict[str, str | dict[str, t.Any]]:
         """Return link dictionary for the resource.
 
         :param resource_type: The type of the resource.
         :type resource_type: str
-        :param base_api_url: The base URL of the API.
-        :type base_api_url: str
         :param url_id: The URL identifier of the resource.
         :type url_id: str
         :return: A dictionary of links.
@@ -76,7 +75,6 @@ class BaseHook:
         *,
         foreign_fields: dict[str, t.Any],
         resource_type: str,
-        base_api_url: str,
         url_id: str,
     ) -> dict[str, dict[str, t.Any]]:
         """Return relationships dictionary for the resource.
@@ -85,8 +83,6 @@ class BaseHook:
         :type foreign_fields: dict[str, t.Any]
         :param resource_type: The type of the resource.
         :type resource_type: str
-        :param base_api_url: The base URL of the API.
-        :type base_api_url: str
         :param url_id: The URL identifier of the resource.
         :type url_id: str
         :return: A dictionary of relationships.
@@ -173,11 +169,10 @@ class ResourceHook(BaseHook):
         cls,
         *,
         resource_type: str,
-        base_api_url: str,
         url_id: str,
     ) -> dict[str, str | dict[str, t.Any]]:
         return {
-            'self': f'{base_api_url}/{resource_type}/{url_id}',
+            'self': f'{API_CONFIG["PREFIX"]}/{resource_type}/{url_id}',
         }
 
     @classmethod
@@ -186,13 +181,12 @@ class ResourceHook(BaseHook):
         *,
         foreign_fields: dict[str, t.Any],
         resource_type: str,
-        base_api_url: str,
         url_id: str,
     ) -> dict[str, dict[str, t.Any]]:
         return {
             'collection': {
                 'links': {
-                    'related': f'{base_api_url}/{resource_type}',
+                    'related': f'{API_CONFIG["PREFIX"]}/{resource_type}',
                 }
             }
         }
@@ -225,13 +219,12 @@ class ComputerHook(EntityHook):
         *,
         foreign_fields: dict[str, t.Any],
         resource_type: str,
-        base_api_url: str,
         url_id: str,
     ) -> dict[str, dict[str, t.Any]]:
         extra = {
             'metadata': {
                 'links': {
-                    'related': f'{base_api_url}/{resource_type}/{url_id}/metadata',
+                    'related': f'{API_CONFIG["PREFIX"]}/{resource_type}/{url_id}/metadata',
                 }
             },
         }
@@ -239,7 +232,6 @@ class ComputerHook(EntityHook):
             super().relationships(
                 foreign_fields=foreign_fields,
                 resource_type=resource_type,
-                base_api_url=base_api_url,
                 url_id=url_id,
             )
             | extra
@@ -257,9 +249,9 @@ class GroupHook(EntityHook):
         *,
         foreign_fields: dict[str, t.Any],
         resource_type: str,
-        base_api_url: str,
         url_id: str,
     ) -> dict[str, dict[str, t.Any]]:
+        base_api_url = API_CONFIG['PREFIX']
         extra = {
             'user': {
                 'links': {
@@ -285,7 +277,6 @@ class GroupHook(EntityHook):
             super().relationships(
                 foreign_fields=foreign_fields,
                 resource_type=resource_type,
-                base_api_url=base_api_url,
                 url_id=url_id,
             )
             | extra
@@ -303,9 +294,9 @@ class NodeHook(EntityHook):
         *,
         foreign_fields: dict[str, t.Any],
         resource_type: str,
-        base_api_url: str,
         url_id: str,
     ) -> dict[str, dict[str, t.Any]]:
+        base_api_url = API_CONFIG['PREFIX']
         extra = {
             'user': {
                 'links': {
@@ -368,7 +359,6 @@ class NodeHook(EntityHook):
             super().relationships(
                 foreign_fields=foreign_fields,
                 resource_type=resource_type,
-                base_api_url=base_api_url,
                 url_id=url_id,
             )
             | extra
@@ -391,9 +381,9 @@ class LinkHook(BaseHook):
         *,
         foreign_fields: dict[str, t.Any],
         resource_type: str,
-        base_api_url: str,
         url_id: str,
     ) -> dict[str, dict[str, t.Any]]:
+        base_api_url = API_CONFIG['PREFIX']
         extra = {}
         if source := foreign_fields.get('source', None):
             extra['source'] = {

--- a/aiida_restapi/jsonapi/hooks.py
+++ b/aiida_restapi/jsonapi/hooks.py
@@ -4,6 +4,7 @@ import typing as t
 
 from aiida import orm
 from aiida.common.exceptions import NotExistent
+from fastapi import Request
 
 from aiida_restapi.config import API_CONFIG
 
@@ -54,12 +55,14 @@ class BaseHook:
     @classmethod
     def links(
         cls,
-        *,
+        request: Request,
         resource_type: str,
         url_id: str,
     ) -> dict[str, str | dict[str, t.Any]]:
         """Return link dictionary for the resource.
 
+        :param request: The incoming request.
+        :type request: Request
         :param resource_type: The type of the resource.
         :type resource_type: str
         :param url_id: The URL identifier of the resource.
@@ -72,6 +75,7 @@ class BaseHook:
     @classmethod
     def relationships(
         cls,
+        request: Request,
         *,
         foreign_fields: dict[str, t.Any],
         resource_type: str,
@@ -79,6 +83,8 @@ class BaseHook:
     ) -> dict[str, dict[str, t.Any]]:
         """Return relationships dictionary for the resource.
 
+        :param request: The incoming request.
+        :type request: Request
         :param foreign_fields: The foreign fields of the resource.
         :type foreign_fields: dict[str, t.Any]
         :param resource_type: The type of the resource.
@@ -167,26 +173,29 @@ class ResourceHook(BaseHook):
     @classmethod
     def links(
         cls,
-        *,
+        request: Request,
         resource_type: str,
         url_id: str,
     ) -> dict[str, str | dict[str, t.Any]]:
+        relative_path = request.scope['root_path'] + API_CONFIG['PREFIX']
         return {
-            'self': f'{API_CONFIG["PREFIX"]}/{resource_type}/{url_id}',
+            'self': f'{relative_path}/{resource_type}/{url_id}',
         }
 
     @classmethod
     def relationships(
         cls,
+        request: Request,
         *,
         foreign_fields: dict[str, t.Any],
         resource_type: str,
         url_id: str,
     ) -> dict[str, dict[str, t.Any]]:
+        relative_path = request.scope['root_path'] + API_CONFIG['PREFIX']
         return {
             'collection': {
                 'links': {
-                    'related': f'{API_CONFIG["PREFIX"]}/{resource_type}',
+                    'related': f'{relative_path}/{resource_type}',
                 }
             }
         }
@@ -216,20 +225,23 @@ class ComputerHook(EntityHook):
     @classmethod
     def relationships(
         cls,
+        request: Request,
         *,
         foreign_fields: dict[str, t.Any],
         resource_type: str,
         url_id: str,
     ) -> dict[str, dict[str, t.Any]]:
+        relative_path = request.scope['root_path'] + API_CONFIG['PREFIX']
         extra = {
             'metadata': {
                 'links': {
-                    'related': f'{API_CONFIG["PREFIX"]}/{resource_type}/{url_id}/metadata',
+                    'related': f'{relative_path}/{resource_type}/{url_id}/metadata',
                 }
             },
         }
         return (
             super().relationships(
+                request,
                 foreign_fields=foreign_fields,
                 resource_type=resource_type,
                 url_id=url_id,
@@ -246,16 +258,17 @@ class GroupHook(EntityHook):
     @classmethod
     def relationships(
         cls,
+        request: Request,
         *,
         foreign_fields: dict[str, t.Any],
         resource_type: str,
         url_id: str,
     ) -> dict[str, dict[str, t.Any]]:
-        base_api_url = API_CONFIG['PREFIX']
+        relative_path = request.scope['root_path'] + API_CONFIG['PREFIX']
         extra = {
             'user': {
                 'links': {
-                    'related': f'{base_api_url}/{resource_type}/{url_id}/user',
+                    'related': f'{relative_path}/{resource_type}/{url_id}/user',
                 },
                 'data': {
                     'id': str(foreign_fields.get('user')),
@@ -264,17 +277,18 @@ class GroupHook(EntityHook):
             },
             'nodes': {
                 'links': {
-                    'related': f'{base_api_url}/{resource_type}/{url_id}/nodes',
+                    'related': f'{relative_path}/{resource_type}/{url_id}/nodes',
                 }
             },
             'extras': {
                 'links': {
-                    'related': f'{base_api_url}/{resource_type}/{url_id}/extras',
+                    'related': f'{relative_path}/{resource_type}/{url_id}/extras',
                 }
             },
         }
         return (
             super().relationships(
+                request,
                 foreign_fields=foreign_fields,
                 resource_type=resource_type,
                 url_id=url_id,
@@ -291,16 +305,17 @@ class NodeHook(EntityHook):
     @classmethod
     def relationships(
         cls,
+        request: Request,
         *,
         foreign_fields: dict[str, t.Any],
         resource_type: str,
         url_id: str,
     ) -> dict[str, dict[str, t.Any]]:
-        base_api_url = API_CONFIG['PREFIX']
+        relative_path = request.scope['root_path'] + API_CONFIG['PREFIX']
         extra = {
             'user': {
                 'links': {
-                    'related': f'{base_api_url}/{resource_type}/{url_id}/user',
+                    'related': f'{relative_path}/{resource_type}/{url_id}/user',
                 },
                 'data': {
                     'id': str(foreign_fields.get('user')),
@@ -314,7 +329,7 @@ class NodeHook(EntityHook):
         if computer_id is not None:
             extra['computer'] = {
                 'links': {
-                    'related': f'{base_api_url}/{resource_type}/{url_id}/computer',
+                    'related': f'{relative_path}/{resource_type}/{url_id}/computer',
                 },
                 'data': {
                     'id': str(computer_id),
@@ -325,38 +340,39 @@ class NodeHook(EntityHook):
         extra |= {
             'groups': {
                 'links': {
-                    'related': f'{base_api_url}/{resource_type}/{url_id}/groups',
+                    'related': f'{relative_path}/{resource_type}/{url_id}/groups',
                 }
             },
             'attributes': {
                 'links': {
-                    'related': f'{base_api_url}/{resource_type}/{url_id}/attributes',
+                    'related': f'{relative_path}/{resource_type}/{url_id}/attributes',
                 }
             },
             'extras': {
                 'links': {
-                    'related': f'{base_api_url}/{resource_type}/{url_id}/extras',
+                    'related': f'{relative_path}/{resource_type}/{url_id}/extras',
                 }
             },
             'repository_metadata': {
                 'links': {
-                    'related': f'{base_api_url}/{resource_type}/{url_id}/repo/metadata',
+                    'related': f'{relative_path}/{resource_type}/{url_id}/repo/metadata',
                 }
             },
             'incoming': {
                 'links': {
-                    'related': f'{base_api_url}/{resource_type}/{url_id}/links?direction=incoming',
+                    'related': f'{relative_path}/{resource_type}/{url_id}/links?direction=incoming',
                 }
             },
             'outgoing': {
                 'links': {
-                    'related': f'{base_api_url}/{resource_type}/{url_id}/links?direction=outgoing',
+                    'related': f'{relative_path}/{resource_type}/{url_id}/links?direction=outgoing',
                 }
             },
         }
 
         return (
             super().relationships(
+                request,
                 foreign_fields=foreign_fields,
                 resource_type=resource_type,
                 url_id=url_id,
@@ -378,17 +394,18 @@ class LinkHook(BaseHook):
     @classmethod
     def relationships(
         cls,
+        request: Request,
         *,
         foreign_fields: dict[str, t.Any],
         resource_type: str,
         url_id: str,
     ) -> dict[str, dict[str, t.Any]]:
-        base_api_url = API_CONFIG['PREFIX']
+        relative_path = request.scope['root_path'] + API_CONFIG['PREFIX']
         extra = {}
         if source := foreign_fields.get('source', None):
             extra['source'] = {
                 'links': {
-                    'related': f'{base_api_url}/nodes/{source}',
+                    'related': f'{relative_path}/nodes/{source}',
                 },
                 'data': {
                     'id': str(source),
@@ -398,7 +415,7 @@ class LinkHook(BaseHook):
         if target := foreign_fields.get('target', None):
             extra['target'] = {
                 'links': {
-                    'related': f'{base_api_url}/nodes/{target}',
+                    'related': f'{relative_path}/nodes/{target}',
                 },
                 'data': {
                     'id': str(target),

--- a/aiida_restapi/main.py
+++ b/aiida_restapi/main.py
@@ -24,9 +24,11 @@ def create_app() -> FastAPI:
     :rtype: FastAPI
     """
 
+    root_path = os.getenv('AIIDA_RESTAPI_ROOT_PATH', '')
     read_only = os.getenv('AIIDA_RESTAPI_READ_ONLY') == '1'
 
     app = FastAPI()
+    app.state.api_path = f'{root_path}{API_CONFIG["PREFIX"]}'
 
     api_router = APIRouter(prefix=API_CONFIG['PREFIX'])
 

--- a/aiida_restapi/routers/server.py
+++ b/aiida_restapi/routers/server.py
@@ -45,10 +45,9 @@ async def get_server_endpoints(request: Request) -> dict[str, list[dict]]:
             continue
 
         group, methods, description = _get_route_parts(route)
-        base_url = str(request.base_url).rstrip('/')
 
         endpoint = {
-            'path': base_url + route.path,
+            'path': route.path,
             'group': group,
             'methods': methods,
             'description': description,
@@ -67,7 +66,6 @@ async def get_server_endpoints(request: Request) -> dict[str, list[dict]]:
 async def get_server_endpoints_table(request: Request) -> HTMLResponse:
     """Get an HTML table of all registered API routes."""
     routes = request.app.routes
-    base_url = str(request.base_url).rstrip('/')
 
     rows = []
 
@@ -75,7 +73,7 @@ async def get_server_endpoints_table(request: Request) -> HTMLResponse:
         if route.path == '/':
             continue
 
-        path = base_url + route.path
+        path = route.path
         group, methods, description = _get_route_parts(route)
 
         disable_url = (

--- a/aiida_restapi/routers/server.py
+++ b/aiida_restapi/routers/server.py
@@ -47,7 +47,7 @@ async def get_server_endpoints(request: Request) -> dict[str, list[dict]]:
         group, methods, description = _get_route_parts(route)
 
         endpoint = {
-            'path': route.path,
+            'path': request.scope['root_path'] + route.path,
             'group': group,
             'methods': methods,
             'description': description,
@@ -73,7 +73,7 @@ async def get_server_endpoints_table(request: Request) -> HTMLResponse:
         if route.path == '/':
             continue
 
-        path = route.path
+        path = request.scope['root_path'] + route.path
         group, methods, description = _get_route_parts(route)
 
         disable_url = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,9 @@ warn_untyped_fields = false
 [tool.pytest.ini_options]
 filterwarnings = [
   'ignore:Creating AiiDA configuration folder.*:UserWarning',
+  'ignore::DeprecationWarning:rewrite:',
+  'ignore::DeprecationWarning:lark:',
+  'ignore::DeprecationWarning:pytz:',
   'ignore::DeprecationWarning:aiida:',
   'ignore::DeprecationWarning:plumpy:',
   'ignore::DeprecationWarning:django:',

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -38,7 +38,7 @@ def test_get_server_endpoints_table(client: TestClient):
 
         # Check that the group, if not empty, is in path immediately after the prefix
         if (group := cols[1].get_text()) != '-':
-            assert path.startswith(f'{client.base_url}{API_CONFIG["PREFIX"]}/{group}')
+            assert path.startswith(f'{API_CONFIG["PREFIX"]}/{group}')
 
         # Check that those endpoints that should be links are indeed links
         method = cols[2].get_text()


### PR DESCRIPTION
This pull request refactors how API URLs and links are constructed throughout the codebase, removing the reliance on a global or static base API URL and instead generating URLs dynamically from the incoming request and application state. Additionally, it introduces a new `--root-path` CLI option for mounting the API under a custom path. These changes improve flexibility, correctness, and support for deployments under subpaths.