### PR TITLE
Process model refactor

### DIFF
--- a/aiida_restapi/models/process.py
+++ b/aiida_restapi/models/process.py
@@ -1,0 +1,56 @@
+import typing as t
+
+import pydantic as pdt
+from aiida import orm
+
+
+def _process_inputs(inputs: dict[str, t.Any]) -> dict[str, t.Any]:
+    """Process the inputs dictionary converting each node UUID into the corresponding node by loading it.
+
+    A node UUID is indicated by the key ending with the suffix ``.uuid``.
+
+    :param inputs: The inputs dictionary.
+    :type inputs: dict[str, t.Any]
+    :returns: The deserialized inputs dictionary.
+    :rtype: dict[str, t.Any]
+    """
+    uuid_suffix = '.uuid'
+    results = {}
+
+    for key, value in inputs.items():
+        if isinstance(value, dict):
+            results[key] = _process_inputs(value)
+        elif key.endswith(uuid_suffix):
+            results[key[: -len(uuid_suffix)]] = orm.load_node(uuid=value)
+        else:
+            results[key] = value
+
+    return results
+
+
+class SubmittedProcess(pdt.BaseModel):
+    label: str = pdt.Field(
+        '',
+        description='The label of the process',
+        examples=['My process', 'Test calculation'],
+    )
+    entry_point: str = pdt.Field(
+        description='The entry point of the process',
+        examples=['core.arithmetic.add'],
+    )
+    inputs: dict[str, t.Any] = pdt.Field(
+        description='The inputs of the process',
+        examples=[{'x': 1, 'y': 2}],
+    )
+
+    @pdt.field_validator('inputs')
+    @classmethod
+    def process_inputs(cls, inputs: dict[str, t.Any]) -> dict[str, t.Any]:
+        """Process the inputs dictionary.
+
+        :param inputs: The inputs to validate.
+        :type inputs: dict[str, t.Any]
+        :returns: The validated inputs.
+        :rtype: dict[str, t.Any]
+        """
+        return _process_inputs(inputs)

--- a/aiida_restapi/models/process.py
+++ b/aiida_restapi/models/process.py
@@ -29,6 +29,8 @@ def _process_inputs(inputs: dict[str, t.Any]) -> dict[str, t.Any]:
 
 
 class SubmittedProcess(pdt.BaseModel):
+    """Pydantic model for submitted processes."""
+
     label: str = pdt.Field(
         '',
         description='The label of the process',

--- a/aiida_restapi/routers/submit.py
+++ b/aiida_restapi/routers/submit.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 import typing as t
 
-import pydantic as pdt
-from aiida import engine, orm
+from aiida import engine
 from aiida.cmdline.utils.decorators import with_dbenv
 from aiida.common import exceptions
 from aiida.plugins.entry_point import load_entry_point_from_string
@@ -14,62 +13,11 @@ from fastapi import APIRouter, Depends, Request
 from aiida_restapi.jsonapi.adapters import JsonApiAdapter as JsonApi
 from aiida_restapi.jsonapi.models import aiida, errors
 from aiida_restapi.jsonapi.responses import JsonApiResponse
+from aiida_restapi.models.process import SubmittedProcess
 
 from .auth import UserInDB, get_current_active_user
 
 write_router = APIRouter(prefix='/submit')
-
-
-def process_inputs(inputs: dict[str, t.Any]) -> dict[str, t.Any]:
-    """Process the inputs dictionary converting each node UUID into the corresponding node by loading it.
-
-    A node UUID is indicated by the key ending with the suffix ``.uuid``.
-
-    :param inputs: The inputs dictionary.
-    :type inputs: dict[str, t.Any]
-    :returns: The deserialized inputs dictionary.
-    :rtype: dict[str, t.Any]
-    """
-    uuid_suffix = '.uuid'
-    results = {}
-
-    for key, value in inputs.items():
-        if isinstance(value, dict):
-            results[key] = process_inputs(value)
-        elif key.endswith(uuid_suffix):
-            results[key[: -len(uuid_suffix)]] = orm.load_node(uuid=value)
-        else:
-            results[key] = value
-
-    return results
-
-
-class ProcessSubmitModel(pdt.BaseModel):
-    label: str = pdt.Field(
-        '',
-        description='The label of the process',
-        examples=['My process', 'Test calculation'],
-    )
-    entry_point: str = pdt.Field(
-        description='The entry point of the process',
-        examples=['core.arithmetic.add'],
-    )
-    inputs: dict[str, t.Any] = pdt.Field(
-        description='The inputs of the process',
-        examples=[{'x': 1, 'y': 2}],
-    )
-
-    @pdt.field_validator('inputs')
-    @classmethod
-    def process_inputs(cls, inputs: dict[str, t.Any]) -> dict[str, t.Any]:
-        """Process the inputs dictionary.
-
-        :param inputs: The inputs to validate.
-        :type inputs: dict[str, t.Any]
-        :returns: The validated inputs.
-        :rtype: dict[str, t.Any]
-        """
-        return process_inputs(inputs)
 
 
 @write_router.post(
@@ -85,7 +33,7 @@ class ProcessSubmitModel(pdt.BaseModel):
 @with_dbenv()
 async def submit_process(
     request: Request,
-    process: ProcessSubmitModel,
+    process: SubmittedProcess,
     current_user: t.Annotated[UserInDB, Depends(get_current_active_user)],
 ) -> dict[str, t.Any]:
     """Submit new AiiDA process."""


### PR DESCRIPTION
Moving the schema for process submission over to a new
/models/process.py module for symmetery/consistency.
This will be mirrored in the new aiida-rest-client.