### PR TITLE
Endpoint pk support

### DIFF
--- a/aiida_restapi/common/types.py
+++ b/aiida_restapi/common/types.py
@@ -5,9 +5,19 @@ from __future__ import annotations
 import typing as t
 
 from aiida import orm
+from fastapi import Request, Response
+from fastapi import exceptions as fastapi_exceptions
 
 EntityType = t.TypeVar('EntityType', bound='orm.Entity')
 EntityModelType = t.TypeVar('EntityModelType', bound='orm.OrmModel')
 
 NodeType = t.TypeVar('NodeType', bound='orm.Node')
 NodeModelType = t.TypeVar('NodeModelType', bound='orm.Node.BaseNodeModel')
+
+RequestValidationErrorHandler = t.Callable[
+    [
+        Request,
+        fastapi_exceptions.RequestValidationError,
+    ],
+    Response | None,
+]

--- a/aiida_restapi/common/types.py
+++ b/aiida_restapi/common/types.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import typing as t
+from uuid import UUID
 
 from aiida import orm
 from fastapi import Request, Response
@@ -13,6 +14,8 @@ EntityModelType = t.TypeVar('EntityModelType', bound='orm.OrmModel')
 
 NodeType = t.TypeVar('NodeType', bound='orm.Node')
 NodeModelType = t.TypeVar('NodeModelType', bound='orm.Node.BaseNodeModel')
+
+EntityIdentifier: t.TypeAlias = int | UUID
 
 RequestValidationErrorHandler = t.Callable[
     [

--- a/aiida_restapi/jsonapi/adapters.py
+++ b/aiida_restapi/jsonapi/adapters.py
@@ -377,6 +377,8 @@ class JsonApiAdapter:
         """
         root = f'{request.scope["root_path"]}{API_CONFIG["PREFIX"]}/{parent_type}'
 
+        pid = str(pid)  # ensure pid is a string for URL construction
+
         return {
             'id': pid,
             'type': child_type,
@@ -390,7 +392,7 @@ class JsonApiAdapter:
                         'related': f'{root}/{pid}',
                     },
                     'data': {
-                        'id': str(pid),
+                        'id': pid,
                         'type': parent_type,
                     },
                 }

--- a/aiida_restapi/main.py
+++ b/aiida_restapi/main.py
@@ -6,12 +6,13 @@ from json import JSONDecodeError
 import pydantic as pdt
 from aiida.common import exceptions as aiida_exceptions
 from aiida.engine.daemon.client import DaemonException
-from fastapi import APIRouter, FastAPI
+from fastapi import APIRouter, FastAPI, Request
 from fastapi import exceptions as fastapi_exceptions
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import RedirectResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 
 from aiida_restapi.common import exceptions as restapi_exceptions
+from aiida_restapi.common.types import RequestValidationErrorHandler
 from aiida_restapi.config import API_CONFIG, CORS_ALLOW_ORIGIN_REGEX, CORS_ORIGIN_URLS
 from aiida_restapi.graphql import main
 from aiida_restapi.jsonapi.utils import jsonapi_error
@@ -47,7 +48,10 @@ def create_app() -> FastAPI:
         lambda _: RedirectResponse(url=api_router.url_path_for('endpoints')),
     )
 
+    request_validation_error_handlers: list[RequestValidationErrorHandler] = []
     for module in (server, users, computers, groups, nodes, querybuilder, submit, daemon, tests):
+        if hasattr(module, 'handle_request_validation_errors'):
+            request_validation_error_handlers.append(module.handle_request_validation_errors)
         if read_router := getattr(module, 'read_router', None):
             api_router.include_router(read_router)
         if not read_only and (write_router := getattr(module, 'write_router', None)):
@@ -88,6 +92,25 @@ def create_app() -> FastAPI:
         }.items()
     }
 
-    app.exception_handlers[fastapi_exceptions.RequestValidationError] = nodes.unsupported_model_error_handler
+    async def handle_request_validation_error(
+        request: Request,
+        exception: fastapi_exceptions.RequestValidationError,
+    ) -> JSONResponse:
+        """Handle request validation errors.
+
+        :param request: The request that caused the validation error.
+        :type request: Request
+        :param exception: The validation error exception.
+        :type exception: fastapi_exceptions.RequestValidationError
+        :return: A JSON response containing the error in JSON:API format.
+        :rtype: JSONResponse
+        """
+        for handler in request_validation_error_handlers:
+            response = handler(request, exception)
+            if response is not None:
+                return response
+        return jsonapi_error(request, exception, 422)
+
+    app.exception_handlers[fastapi_exceptions.RequestValidationError] = handle_request_validation_error
 
     return app

--- a/aiida_restapi/routers/computers.py
+++ b/aiida_restapi/routers/computers.py
@@ -9,6 +9,7 @@ from aiida.cmdline.utils.decorators import with_dbenv
 from fastapi import APIRouter, Depends, Query, Request
 
 from aiida_restapi.common import query
+from aiida_restapi.common.types import EntityIdentifier
 from aiida_restapi.jsonapi.adapters import JsonApiAdapter as JsonApi
 from aiida_restapi.jsonapi.models import errors
 from aiida_restapi.jsonapi.models.aiida import ComputerCollectionDocument, ComputerResourceDocument
@@ -80,7 +81,7 @@ async def get_computers(
 
 
 @read_router.get(
-    '/{pk}',
+    '/{identifier}',
     response_class=JsonApiResponse,
     response_model=ComputerResourceDocument,
     response_model_exclude_none=True,
@@ -93,14 +94,14 @@ async def get_computers(
 @with_dbenv()
 async def get_computer(
     request: Request,
-    pk: int,
+    identifier: EntityIdentifier,
     query_params: t.Annotated[
         query.ResourceQueryParams,
         Depends(query.resource_query_params),
     ],
 ) -> dict[str, t.Any]:
-    """Get AiiDA computer by pk."""
-    result = service.get_one(pk)
+    """Get AiiDA computer."""
+    result = service.get_one(identifier)
     return JsonApi.resource(
         request,
         result,
@@ -111,7 +112,7 @@ async def get_computer(
 
 
 @read_router.get(
-    '/{pk}/metadata',
+    '/{identifier}/metadata',
     response_class=JsonApiResponse,
     response_model=JsonApiResourceDocument,
     response_model_exclude_none=True,
@@ -127,18 +128,19 @@ async def get_computer(
 @with_dbenv()
 async def get_computer_metadata(
     request: Request,
-    pk: int,
+    identifier: EntityIdentifier,
     query_params: t.Annotated[
         query.ResourceQueryParams,
         Depends(query.resource_query_params),
     ],
 ) -> dict[str, t.Any]:
-    """Get metadata of an AiiDA computer by pk."""
-    metadata = service.get_field(pk, 'metadata')
+    """Get metadata of an AiiDA computer."""
+    computer = service.load_one(identifier)
+    metadata = service.get_field(identifier, 'metadata')
     return JsonApi.child_resource(
         request,
         metadata,
-        pid=pk,
+        pid=computer.uuid,
         parent_type='computers',
         child_type='metadata',
         include=query_params.include,

--- a/aiida_restapi/routers/computers.py
+++ b/aiida_restapi/routers/computers.py
@@ -127,7 +127,7 @@ async def get_computer(
 @with_dbenv()
 async def get_computer_metadata(
     request: Request,
-    pk: str,
+    pk: int,
     query_params: t.Annotated[
         query.ResourceQueryParams,
         Depends(query.resource_query_params),
@@ -138,7 +138,7 @@ async def get_computer_metadata(
     return JsonApi.child_resource(
         request,
         metadata,
-        pid=str(pk),
+        pid=pk,
         parent_type='computers',
         child_type='metadata',
         include=query_params.include,

--- a/aiida_restapi/routers/groups.py
+++ b/aiida_restapi/routers/groups.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import typing as t
-from uuid import UUID
 
 from aiida import orm
 from aiida.cmdline.utils.decorators import with_dbenv
 from fastapi import APIRouter, Depends, Query, Request
 
 from aiida_restapi.common import query
+from aiida_restapi.common.types import EntityIdentifier
 from aiida_restapi.jsonapi.adapters import JsonApiAdapter as JsonApi
 from aiida_restapi.jsonapi.models import errors
 from aiida_restapi.jsonapi.models.aiida import (
@@ -99,13 +99,13 @@ async def get_groups(
 @with_dbenv()
 async def get_group(
     request: Request,
-    identifier: int | UUID,
+    identifier: EntityIdentifier,
     query_params: t.Annotated[
         query.ResourceQueryParams,
         Depends(query.resource_query_params),
     ],
 ) -> dict[str, t.Any]:
-    """Get AiiDA group by identifier (UUID or PK)."""
+    """Get AiiDA group."""
     result = service.get_one(identifier)
     return JsonApi.resource(
         request,
@@ -130,7 +130,7 @@ async def get_group(
 @with_dbenv()
 async def get_group_user(
     request: Request,
-    identifier: int | UUID,
+    identifier: EntityIdentifier,
 ) -> dict[str, t.Any]:
     """Get the user associated with a group."""
     user = service.get_related_one(identifier, orm.User)
@@ -159,7 +159,7 @@ async def get_group_user(
 @with_dbenv()
 async def get_group_nodes(
     request: Request,
-    identifier: int | UUID,
+    identifier: EntityIdentifier,
     query_params: t.Annotated[
         query.CollectionQueryParams,
         Depends(query.collection_query_params),
@@ -193,7 +193,7 @@ async def get_group_nodes(
 @with_dbenv()
 async def get_group_extras(
     request: Request,
-    identifier: int | UUID,
+    identifier: EntityIdentifier,
     query_params: t.Annotated[
         query.ResourceQueryParams,
         Depends(query.resource_query_params),

--- a/aiida_restapi/routers/groups.py
+++ b/aiida_restapi/routers/groups.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import typing as t
+from uuid import UUID
 
 from aiida import orm
 from aiida.cmdline.utils.decorators import with_dbenv
@@ -85,7 +86,7 @@ async def get_groups(
 
 
 @read_router.get(
-    '/{uuid}',
+    '/{identifier}',
     response_class=JsonApiResponse,
     response_model=GroupResourceDocument,
     response_model_exclude_none=True,
@@ -98,14 +99,14 @@ async def get_groups(
 @with_dbenv()
 async def get_group(
     request: Request,
-    uuid: str,
+    identifier: int | UUID,
     query_params: t.Annotated[
         query.ResourceQueryParams,
         Depends(query.resource_query_params),
     ],
 ) -> dict[str, t.Any]:
-    """Get AiiDA group by uuid."""
-    result = service.get_one(uuid)
+    """Get AiiDA group by identifier (UUID or PK)."""
+    result = service.get_one(identifier)
     return JsonApi.resource(
         request,
         result,
@@ -116,7 +117,7 @@ async def get_group(
 
 
 @read_router.get(
-    '/{uuid}/user',
+    '/{identifier}/user',
     response_class=JsonApiResponse,
     response_model=UserResourceDocument,
     response_model_exclude_none=True,
@@ -127,9 +128,12 @@ async def get_group(
     },
 )
 @with_dbenv()
-async def get_group_user(request: Request, uuid: str) -> dict[str, t.Any]:
+async def get_group_user(
+    request: Request,
+    identifier: int | UUID,
+) -> dict[str, t.Any]:
     """Get the user associated with a group."""
-    user = service.get_related_one(uuid, orm.User)
+    user = service.get_related_one(identifier, orm.User)
     return JsonApi.resource(
         request,
         user,
@@ -139,7 +143,7 @@ async def get_group_user(request: Request, uuid: str) -> dict[str, t.Any]:
 
 
 @read_router.get(
-    '/{uuid}/nodes',
+    '/{identifier}/nodes',
     response_class=JsonApiResponse,
     response_model=NodeCollectionDocument,
     response_model_exclude_none=True,
@@ -155,14 +159,14 @@ async def get_group_user(request: Request, uuid: str) -> dict[str, t.Any]:
 @with_dbenv()
 async def get_group_nodes(
     request: Request,
-    uuid: str,
+    identifier: int | UUID,
     query_params: t.Annotated[
         query.CollectionQueryParams,
         Depends(query.collection_query_params),
     ],
 ) -> dict[str, t.Any]:
     """Get the nodes of a group."""
-    nodes = service.get_related_many(uuid, orm.Node, query_params)
+    nodes = service.get_related_many(identifier, orm.Node, query_params)
     return JsonApi.collection(
         request,
         nodes,
@@ -173,7 +177,7 @@ async def get_group_nodes(
 
 
 @read_router.get(
-    '/{uuid}/extras',
+    '/{identifier}/extras',
     response_class=JsonApiResponse,
     response_model=JsonApiResourceDocument,
     response_model_exclude_none=True,
@@ -189,18 +193,19 @@ async def get_group_nodes(
 @with_dbenv()
 async def get_group_extras(
     request: Request,
-    uuid: str,
+    identifier: int | UUID,
     query_params: t.Annotated[
         query.ResourceQueryParams,
         Depends(query.resource_query_params),
     ],
 ) -> dict[str, t.Any]:
     """Get the extras of a group."""
-    extras = service.get_field(uuid, 'extras')
+    group = service.load_one(identifier)
+    extras = service.get_field(identifier, 'extras')
     return JsonApi.child_resource(
         request,
         extras,
-        pid=uuid,
+        pid=group.uuid,
         parent_type='groups',
         child_type='extras',
         include=query_params.include,

--- a/aiida_restapi/routers/nodes.py
+++ b/aiida_restapi/routers/nodes.py
@@ -6,7 +6,6 @@ import io
 import json
 import typing as t
 from urllib.parse import quote
-from uuid import UUID
 
 import pydantic as pdt
 from aiida import orm
@@ -20,6 +19,7 @@ from typing_extensions import TypeAlias
 
 from aiida_restapi.common import exceptions as restapi_exceptions
 from aiida_restapi.common import query
+from aiida_restapi.common.types import EntityIdentifier
 from aiida_restapi.config import API_CONFIG
 from aiida_restapi.jsonapi.adapters import JsonApiAdapter as JsonApi
 from aiida_restapi.jsonapi.models import aiida, errors
@@ -210,13 +210,13 @@ async def get_node_types() -> list:
 @with_dbenv()
 async def get_node(
     request: Request,
-    identifier: int | UUID,
+    identifier: EntityIdentifier,
     query_params: t.Annotated[
         query.ResourceQueryParams,
         Depends(query.resource_query_params),
     ],
 ) -> dict[str, t.Any]:
-    """Get AiiDA node by identifier (UUID or PK)."""
+    """Get AiiDA node."""
     result = service.get_one(identifier)
     return JsonApi.resource(
         request,
@@ -241,7 +241,7 @@ async def get_node(
 @with_dbenv()
 async def get_node_user(
     request: Request,
-    identifier: int | UUID,
+    identifier: EntityIdentifier,
 ) -> dict[str, t.Any]:
     """Get the user associated with a node."""
     user = service.get_related_one(identifier, orm.User)
@@ -267,7 +267,7 @@ async def get_node_user(
 @with_dbenv()
 async def get_node_computer(
     request: Request,
-    identifier: int | UUID,
+    identifier: EntityIdentifier,
 ) -> dict[str, t.Any]:
     """Get the computer associated with a node."""
     computer = service.get_related_one(identifier, orm.Computer)
@@ -296,7 +296,7 @@ async def get_node_computer(
 @with_dbenv()
 async def get_node_groups(
     request: Request,
-    identifier: int | UUID,
+    identifier: EntityIdentifier,
     query_params: t.Annotated[
         query.CollectionQueryParams,
         Depends(query.collection_query_params),
@@ -330,7 +330,7 @@ async def get_node_groups(
 @with_dbenv()
 async def get_node_attributes(
     request: Request,
-    identifier: int | UUID,
+    identifier: EntityIdentifier,
     query_params: t.Annotated[
         query.ResourceQueryParams,
         Depends(query.resource_query_params),
@@ -366,7 +366,7 @@ async def get_node_attributes(
 @with_dbenv()
 async def get_node_extras(
     request: Request,
-    identifier: int | UUID,
+    identifier: EntityIdentifier,
     query_params: t.Annotated[
         query.ResourceQueryParams,
         Depends(query.resource_query_params),
@@ -399,7 +399,7 @@ async def get_node_extras(
 @with_dbenv()
 async def get_node_links(
     request: Request,
-    identifier: int | UUID,
+    identifier: EntityIdentifier,
     direction: t.Annotated[
         t.Literal['incoming', 'outgoing'],
         Query(description='Specify whether to retrieve incoming or outgoing links.'),
@@ -434,7 +434,7 @@ async def get_node_links(
 @with_dbenv()
 async def get_node_repo_file_metadata(
     request: Request,
-    identifier: int | UUID,
+    identifier: EntityIdentifier,
     query_params: t.Annotated[
         query.ResourceQueryParams,
         Depends(query.resource_query_params),
@@ -473,7 +473,7 @@ def get_file_download_headers(filename: str) -> dict[str, str]:
 )
 @with_dbenv()
 async def get_node_repo_file_contents(
-    identifier: int | UUID,
+    identifier: EntityIdentifier,
     filename: t.Annotated[
         str | None,
         Query(description='Filename of repository content to retrieve'),
@@ -502,7 +502,7 @@ async def get_node_repo_file_contents(
 )
 @with_dbenv()
 async def download_node(
-    identifier: int | UUID,
+    identifier: EntityIdentifier,
     format: t.Annotated[
         str | None,
         Query(description='Format to download the node in'),
@@ -692,7 +692,7 @@ async def create_node_with_files(
 @with_dbenv()
 async def update_node(
     request: Request,
-    identifier: int | UUID,
+    identifier: EntityIdentifier,
     model: orm.Node.MutableNodeFields,
 ) -> dict[str, t.Any]:
     """Update the mutable fields of an existing AiiDA node.

--- a/aiida_restapi/routers/nodes.py
+++ b/aiida_restapi/routers/nodes.py
@@ -6,6 +6,7 @@ import io
 import json
 import typing as t
 from urllib.parse import quote
+from uuid import UUID
 
 import pydantic as pdt
 from aiida import orm
@@ -13,7 +14,6 @@ from aiida.cmdline.utils.decorators import with_dbenv
 from aiida.common import exceptions as aiida_exceptions
 from fastapi import APIRouter, Body, Depends, Form, Query, Request, Response, UploadFile
 from fastapi import exceptions as fastapi_exceptions
-from fastapi.exception_handlers import request_validation_exception_handler
 from fastapi.exceptions import ValidationException
 from fastapi.responses import StreamingResponse
 from typing_extensions import TypeAlias
@@ -47,25 +47,30 @@ else:
     NodeConstructorModelUnion = model_registry.ConstructorModelUnion
 
 
-async def unsupported_model_error_handler(
+def handle_request_validation_errors(
     request: Request,
     exception: fastapi_exceptions.RequestValidationError,
-) -> Response:
-    """Return concise validation errors for selected request-validation cases."""
-    if request.method == 'POST' and (
-        request.url.path.endswith('/nodes') or request.url.path.endswith('/nodes/constructor')
-    ):
+) -> Response | None:
+    """Handle special request validation errors cases for node routes.
+
+    :param request: The request that caused the validation error.
+    :type request: Request
+    :param exception: The validation error exception.
+    :type exception: fastapi_exceptions.RequestValidationError
+    :return: A JSON response containing the error in JSON:API format.
+    :rtype: JSONResponse
+    """
+    if request.method == 'POST' and '/nodes' in request.url.path:
         body = getattr(exception, 'body', None)
         if isinstance(body, dict):
             try:
-                which = 'constructor' if request.url.path.endswith('/nodes/constructor') else None
+                which = 'constructor' if request.url.path.endswith('/constructor') else None
                 model_registry.get_post_model_from_payload(body, which)  # type: ignore[arg-type]
             except aiida_exceptions.UnsupportedSchemaError as unsupported:
                 return jsonapi_error(request, unsupported, 422)
             except ValueError:
                 pass
-
-    return await request_validation_exception_handler(request, exception)
+    return None
 
 
 @read_router.get(
@@ -192,7 +197,7 @@ async def get_node_types() -> list:
 
 
 @read_router.get(
-    '/{uuid}',
+    '/{identifier}',
     response_class=JsonApiResponse,
     response_model=aiida.NodeResourceDocument,
     response_model_exclude_none=True,
@@ -205,14 +210,14 @@ async def get_node_types() -> list:
 @with_dbenv()
 async def get_node(
     request: Request,
-    uuid: str,
+    identifier: int | UUID,
     query_params: t.Annotated[
         query.ResourceQueryParams,
         Depends(query.resource_query_params),
     ],
 ) -> dict[str, t.Any]:
-    """Get AiiDA node by uuid."""
-    result = service.get_one(uuid)
+    """Get AiiDA node by identifier (UUID or PK)."""
+    result = service.get_one(identifier)
     return JsonApi.resource(
         request,
         result,
@@ -223,7 +228,7 @@ async def get_node(
 
 
 @read_router.get(
-    '/{uuid}/user',
+    '/{identifier}/user',
     response_class=JsonApiResponse,
     response_model=aiida.UserResourceDocument,
     response_model_exclude_none=True,
@@ -234,9 +239,12 @@ async def get_node(
     },
 )
 @with_dbenv()
-async def get_node_user(request: Request, uuid: str) -> dict[str, t.Any]:
+async def get_node_user(
+    request: Request,
+    identifier: int | UUID,
+) -> dict[str, t.Any]:
     """Get the user associated with a node."""
-    user = service.get_related_one(uuid, orm.User)
+    user = service.get_related_one(identifier, orm.User)
     return JsonApi.resource(
         request,
         user,
@@ -246,7 +254,7 @@ async def get_node_user(request: Request, uuid: str) -> dict[str, t.Any]:
 
 
 @read_router.get(
-    '/{uuid}/computer',
+    '/{identifier}/computer',
     response_class=JsonApiResponse,
     response_model=aiida.ComputerResourceDocument,
     response_model_exclude_none=True,
@@ -257,9 +265,12 @@ async def get_node_user(request: Request, uuid: str) -> dict[str, t.Any]:
     },
 )
 @with_dbenv()
-async def get_node_computer(request: Request, uuid: str) -> dict[str, t.Any]:
+async def get_node_computer(
+    request: Request,
+    identifier: int | UUID,
+) -> dict[str, t.Any]:
     """Get the computer associated with a node."""
-    computer = service.get_related_one(uuid, orm.Computer)
+    computer = service.get_related_one(identifier, orm.Computer)
     return JsonApi.resource(
         request,
         computer,
@@ -269,7 +280,7 @@ async def get_node_computer(request: Request, uuid: str) -> dict[str, t.Any]:
 
 
 @read_router.get(
-    '/{uuid}/groups',
+    '/{identifier}/groups',
     response_class=JsonApiResponse,
     response_model=aiida.GroupCollectionDocument,
     response_model_exclude_none=True,
@@ -285,14 +296,14 @@ async def get_node_computer(request: Request, uuid: str) -> dict[str, t.Any]:
 @with_dbenv()
 async def get_node_groups(
     request: Request,
-    uuid: str,
+    identifier: int | UUID,
     query_params: t.Annotated[
         query.CollectionQueryParams,
         Depends(query.collection_query_params),
     ],
 ) -> dict[str, t.Any]:
     """Get the groups of a node."""
-    groups = service.get_related_many(uuid, orm.Group, query_params)
+    groups = service.get_related_many(identifier, orm.Group, query_params)
     return JsonApi.collection(
         request,
         groups,
@@ -303,7 +314,7 @@ async def get_node_groups(
 
 
 @read_router.get(
-    '/{uuid}/attributes',
+    '/{identifier}/attributes',
     response_class=JsonApiResponse,
     response_model=JsonApiResourceDocument,
     response_model_exclude_none=True,
@@ -319,18 +330,19 @@ async def get_node_groups(
 @with_dbenv()
 async def get_node_attributes(
     request: Request,
-    uuid: str,
+    identifier: int | UUID,
     query_params: t.Annotated[
         query.ResourceQueryParams,
         Depends(query.resource_query_params),
     ],
 ) -> dict[str, t.Any]:
     """Get the attributes of a node."""
-    attributes = service.get_field(uuid, 'attributes')
+    node = service.load_one(identifier)
+    attributes = service.get_field(identifier, 'attributes')
     return JsonApi.child_resource(
         request,
         attributes,
-        pid=uuid,
+        pid=node.uuid,
         parent_type='nodes',
         child_type='attributes',
         include=query_params.include,
@@ -338,7 +350,7 @@ async def get_node_attributes(
 
 
 @read_router.get(
-    '/{uuid}/extras',
+    '/{identifier}/extras',
     response_class=JsonApiResponse,
     response_model=JsonApiResourceDocument,
     response_model_exclude_none=True,
@@ -354,18 +366,19 @@ async def get_node_attributes(
 @with_dbenv()
 async def get_node_extras(
     request: Request,
-    uuid: str,
+    identifier: int | UUID,
     query_params: t.Annotated[
         query.ResourceQueryParams,
         Depends(query.resource_query_params),
     ],
 ) -> dict[str, t.Any]:
     """Get the extras of a node."""
-    extras = service.get_field(uuid, 'extras')
+    node = service.load_one(identifier)
+    extras = service.get_field(identifier, 'extras')
     return JsonApi.child_resource(
         request,
         extras,
-        pid=uuid,
+        pid=node.uuid,
         parent_type='nodes',
         child_type='extras',
         include=query_params.include,
@@ -373,7 +386,7 @@ async def get_node_extras(
 
 
 @read_router.get(
-    '/{uuid}/links',
+    '/{identifier}/links',
     response_class=JsonApiResponse,
     response_model=aiida.LinkCollectionDocument,
     response_model_exclude_none=True,
@@ -386,7 +399,7 @@ async def get_node_extras(
 @with_dbenv()
 async def get_node_links(
     request: Request,
-    uuid: str,
+    identifier: int | UUID,
     direction: t.Annotated[
         t.Literal['incoming', 'outgoing'],
         Query(description='Specify whether to retrieve incoming or outgoing links.'),
@@ -397,7 +410,7 @@ async def get_node_links(
     ],
 ) -> dict[str, t.Any]:
     """Get the incoming/outgoing links of a node."""
-    links = service.get_links(uuid, direction, query_params)
+    links = service.get_links(identifier, direction, query_params)
     return JsonApi.collection(
         request,
         links,
@@ -408,7 +421,7 @@ async def get_node_links(
 
 
 @read_router.get(
-    '/{uuid}/repo/metadata',
+    '/{identifier}/repo/metadata',
     response_class=JsonApiResponse,
     response_model=JsonApiResourceDocument,
     response_model_exclude_none=True,
@@ -421,18 +434,19 @@ async def get_node_links(
 @with_dbenv()
 async def get_node_repo_file_metadata(
     request: Request,
-    uuid: str,
+    identifier: int | UUID,
     query_params: t.Annotated[
         query.ResourceQueryParams,
         Depends(query.resource_query_params),
     ],
 ) -> dict[str, t.Any]:
     """Get the repository file metadata of a node."""
-    metadata = service.get_repository_metadata(uuid)
+    node = service.load_one(identifier)
+    metadata = service.get_repository_metadata(identifier)
     return JsonApi.child_resource(
         request,
         metadata,
-        pid=uuid,
+        pid=node.uuid,
         parent_type='nodes',
         child_type='repo-metadata',
         include=query_params.include,
@@ -449,7 +463,7 @@ def get_file_download_headers(filename: str) -> dict[str, str]:
 
 
 @read_router.get(
-    '/{uuid}/repo/contents',
+    '/{identifier}/repo/contents',
     response_class=StreamingResponse,
     responses={
         404: {'model': errors.NonExistentError, 'description': 'Resource Not Found'},
@@ -459,16 +473,16 @@ def get_file_download_headers(filename: str) -> dict[str, str]:
 )
 @with_dbenv()
 async def get_node_repo_file_contents(
-    uuid: str,
+    identifier: int | UUID,
     filename: t.Annotated[
         str | None,
         Query(description='Filename of repository content to retrieve'),
     ] = None,
 ) -> StreamingResponse:
     """Get the repository contents of a node."""
-    node = orm.load_node(uuid)
+    node = service.load_one(identifier)
     repo = node.base.repository
-    repo_filename = filename.strip('/')[-1] if filename else f'{uuid}.zip'
+    repo_filename = filename.strip('/')[-1] if filename else f'{node.uuid}.zip'
     return StreamingResponse(
         stream_bytes(repo.get_object_content(filename, mode='rb') if filename else repo.get_zipped_objects()),
         media_type=f'application/{"zip" if not filename else "octet-stream"}',
@@ -477,7 +491,7 @@ async def get_node_repo_file_contents(
 
 
 @read_router.get(
-    '/{uuid}/download',
+    '/{identifier}/download',
     response_class=StreamingResponse,
     responses={
         404: {'model': errors.NonExistentError, 'description': 'Resource Not Found'},
@@ -488,7 +502,7 @@ async def get_node_repo_file_contents(
 )
 @with_dbenv()
 async def download_node(
-    uuid: str,
+    identifier: int | UUID,
     format: t.Annotated[
         str | None,
         Query(description='Format to download the node in'),
@@ -498,7 +512,7 @@ async def download_node(
         Query(description='Additional options for archive downloads, provided as a JSON string'),
     ] = None,
 ) -> StreamingResponse:
-    """Download AiiDA node by uuid in a given download format (e.g., JSON, archive).
+    """Download AiiDA node by identifier (UUID or PK) in a given format (e.g., JSON, archive).
 
     The available download formats can be queried using the /nodes/download_formats/ endpoint.
     If downloading as an archive, additional options can be provided as a JSON object via the
@@ -512,12 +526,12 @@ async def download_node(
             'queried using the /nodes/download_formats endpoint.',
         )
 
-    node = orm.load_node(uuid)
+    node = service.load_one(identifier)
 
     if format == 'archive':
         from aiida.tools.archive import create_archive
 
-        filename = f'{uuid}.aiida'
+        filename = f'{node.uuid}.aiida'
 
         if options:
             try:
@@ -531,7 +545,7 @@ async def download_node(
         exported_bytes = archive_path.read_bytes()
         archive_path.unlink()
     elif format in node.get_export_formats():
-        filename = f'{uuid}.{format}'
+        filename = f'{node.uuid}.{format}'
         exported_bytes, _ = node._exportcontent(format)
     else:
         raise ValidationException(
@@ -661,7 +675,7 @@ async def create_node_with_files(
 
 
 @write_router.patch(
-    '/{uuid}',
+    '/{identifier}',
     response_class=JsonApiResponse,
     response_model=aiida.NodeResourceDocument,
     response_model_exclude_none=True,
@@ -678,14 +692,14 @@ async def create_node_with_files(
 @with_dbenv()
 async def update_node(
     request: Request,
-    uuid: str,
+    identifier: int | UUID,
     model: orm.Node.MutableNodeFields,
 ) -> dict[str, t.Any]:
     """Update the mutable fields of an existing AiiDA node.
 
     Updatable fields: 'label', 'description', 'extras'
     """
-    result = service.update(uuid, model)
+    result = service.update(identifier, model)
     return JsonApi.resource(
         request,
         result,

--- a/aiida_restapi/routers/users.py
+++ b/aiida_restapi/routers/users.py
@@ -7,6 +7,7 @@ import typing as t
 from aiida import orm
 from aiida.cmdline.utils.decorators import with_dbenv
 from fastapi import APIRouter, Depends, Query, Request
+from pydantic import PlainValidator
 
 from aiida_restapi.common import query
 from aiida_restapi.jsonapi.adapters import JsonApiAdapter as JsonApi
@@ -19,6 +20,16 @@ read_router = APIRouter(prefix='/users')
 write_router = APIRouter(prefix='/users')
 
 service = EntityService[orm.User, orm.User.ReadModel](orm.User)
+
+
+def validate_user_email(value: str) -> str:
+    if value.count('@') != 1:
+        raise ValueError('Invalid email address - must contain exactly one "@"')
+    return value
+
+
+UserEmail: t.TypeAlias = t.Annotated[str, PlainValidator(validate_user_email)]
+UserIdentifier: t.TypeAlias = int | UserEmail
 
 
 @read_router.get(
@@ -79,7 +90,7 @@ async def get_users(
 
 
 @read_router.get(
-    '/{pk}',
+    '/{identifier}',
     response_class=JsonApiResponse,
     response_model=UserResourceDocument,
     response_model_exclude_none=True,
@@ -92,14 +103,19 @@ async def get_users(
 @with_dbenv()
 async def get_user(
     request: Request,
-    pk: int,
+    identifier: UserIdentifier,
     query_params: t.Annotated[
         query.ResourceQueryParams,
         Depends(query.resource_query_params),
     ],
 ) -> dict[str, t.Any]:
-    """Get AiiDA user by pk."""
-    result = service.get_one(pk)
+    """Get AiiDA user."""
+    # HACK AiiDA User does not have a UUID - see https://github.com/aiidateam/aiida-core/issues/6174
+    key = 'pk' if isinstance(identifier, int) else 'email'
+    print(key, identifier)
+    user = orm.User.collection.get(**{key: identifier})  # we need the EntityIdentifier-compatible user pk
+    assert user.pk  # appeasing mypy - something is terribly wrong if pk is None!
+    result = service.get_one(user.pk)
     return JsonApi.resource(
         request,
         result,

--- a/aiida_restapi/routers/users.py
+++ b/aiida_restapi/routers/users.py
@@ -7,7 +7,6 @@ import typing as t
 from aiida import orm
 from aiida.cmdline.utils.decorators import with_dbenv
 from fastapi import APIRouter, Depends, Query, Request
-from pydantic import PlainValidator
 
 from aiida_restapi.common import query
 from aiida_restapi.jsonapi.adapters import JsonApiAdapter as JsonApi
@@ -20,16 +19,6 @@ read_router = APIRouter(prefix='/users')
 write_router = APIRouter(prefix='/users')
 
 service = EntityService[orm.User, orm.User.ReadModel](orm.User)
-
-
-def validate_user_email(value: str) -> str:
-    if value.count('@') != 1:
-        raise ValueError('Invalid email address - must contain exactly one "@"')
-    return value
-
-
-UserEmail: t.TypeAlias = t.Annotated[str, PlainValidator(validate_user_email)]
-UserIdentifier: t.TypeAlias = int | UserEmail
 
 
 @read_router.get(
@@ -103,19 +92,14 @@ async def get_users(
 @with_dbenv()
 async def get_user(
     request: Request,
-    identifier: UserIdentifier,
+    identifier: int,
     query_params: t.Annotated[
         query.ResourceQueryParams,
         Depends(query.resource_query_params),
     ],
 ) -> dict[str, t.Any]:
     """Get AiiDA user."""
-    # HACK AiiDA User does not have a UUID - see https://github.com/aiidateam/aiida-core/issues/6174
-    key = 'pk' if isinstance(identifier, int) else 'email'
-    print(key, identifier)
-    user = orm.User.collection.get(**{key: identifier})  # we need the EntityIdentifier-compatible user pk
-    assert user.pk  # appeasing mypy - something is terribly wrong if pk is None!
-    result = service.get_one(user.pk)
+    result = service.get_one(identifier)
     return JsonApi.resource(
         request,
         result,

--- a/aiida_restapi/services/entity.py
+++ b/aiida_restapi/services/entity.py
@@ -1,4 +1,4 @@
-"""REST API entity repository."""
+"""REST API entity service."""
 
 from __future__ import annotations
 
@@ -12,7 +12,7 @@ from aiida.common.pydantic import get_metadata
 from aiida_restapi.common.exceptions import QueryBuilderException
 from aiida_restapi.common.pagination import PaginatedResults
 from aiida_restapi.common.query import QueryBuilderParams
-from aiida_restapi.common.types import EntityModelType, EntityType
+from aiida_restapi.common.types import EntityIdentifier, EntityModelType, EntityType
 
 
 class EntityService(t.Generic[EntityType, EntityModelType]):
@@ -65,11 +65,11 @@ class EntityService(t.Generic[EntityType, EntityModelType]):
         """
         return self.entity_class.fields.keys()
 
-    def get_one(self, identifier: int | UUID) -> dict[str, t.Any]:
+    def get_one(self, identifier: EntityIdentifier) -> dict[str, t.Any]:
         """Get an AiiDA entity by id.
 
         :param identifier: The identifier of the entity to retrieve.
-        :type identifier: int | UUID
+        :type identifier: EntityIdentifier
         :return: The serialized AiiDA entity.
         :rtype: dict[str, t.Any]
         """
@@ -79,11 +79,11 @@ class EntityService(t.Generic[EntityType, EntityModelType]):
             raise NotExistent(f'{self.entity_class.__name__}<{identifier}> does not exist.') from exception
         return entity.serialize(minimal=True)
 
-    def load_one(self, identifier: int | UUID) -> EntityType:
+    def load_one(self, identifier: EntityIdentifier) -> EntityType:
         """Load an entity using strict UUID-or-PK resolution.
 
         :param identifier: The identifier of the entity to load.
-        :type identifier: int | UUID
+        :type identifier: EntityIdentifier
         :return: The loaded AiiDA entity.
         :rtype: EntityType
         """
@@ -117,13 +117,13 @@ class EntityService(t.Generic[EntityType, EntityModelType]):
 
     def get_related_one(
         self,
-        identifier: int | UUID,
+        identifier: EntityIdentifier,
         related_type: type[orm.Entity],
     ) -> dict[str, t.Any]:
         """Get a related foreign entity of an entity.
 
         :param identifier: The identifier of the entity to retrieve the foreign entity for.
-        :type identifier: int | UUID
+        :type identifier: EntityIdentifier
         :param related_type: The related AiiDA ORM entity class to retrieve.
         :type related_type: type[orm.Entity]
         :return: The related foreign entity.
@@ -158,14 +158,14 @@ class EntityService(t.Generic[EntityType, EntityModelType]):
 
     def get_related_many(
         self,
-        identifier: int | UUID,
+        identifier: EntityIdentifier,
         related_type: type[orm.Entity],
         query_params: QueryBuilderParams,
     ) -> PaginatedResults[dict[str, t.Any]]:
         """Get related foreign entities of an entity.
 
         :param identifier: The identifier of the entity to retrieve the foreign entities for.
-        :type identifier: int | UUID
+        :type identifier: EntityIdentifier
         :param related_type: The related AiiDA ORM entity class to retrieve.
         :type related_type: type[orm.Entity]
         :param query_params: The query parameters, including filters, order_by, page_size, and page.
@@ -209,11 +209,11 @@ class EntityService(t.Generic[EntityType, EntityModelType]):
             data=[next(iter(result.values())) for result in results],
         )
 
-    def get_field(self, identifier: int | UUID, field: str) -> t.Any:
+    def get_field(self, identifier: EntityIdentifier, field: str) -> t.Any:
         """Get a specific field of an entity.
 
         :param identifier: The identifier of the entity to retrieve the extras for.
-        :type identifier: int | UUID
+        :type identifier: EntityIdentifier
         :param field: The specific field to retrieve.
         :type field: str
         :return: The value of the specified field.
@@ -245,11 +245,11 @@ class EntityService(t.Generic[EntityType, EntityModelType]):
         entity = self.entity_class.from_model(model).store()
         return entity.serialize(minimal=True)
 
-    def update(self, identifier: int | UUID, model: EntityModelType) -> dict[str, t.Any]:
+    def update(self, identifier: EntityIdentifier, model: EntityModelType) -> dict[str, t.Any]:
         """Update an existing AiiDA entity.
 
         :param identifier: The identifier of the entity to update.
-        :type identifier: int | UUID
+        :type identifier: EntityIdentifier
         :param model: The Pydantic model of the entity to update.
         :type model: EntityModelType
         :return: The updated and stored AiiDA `Entity` instance.
@@ -259,11 +259,11 @@ class EntityService(t.Generic[EntityType, EntityModelType]):
         self._apply_update(entity, model)
         return entity.serialize(minimal=True)
 
-    def _lookup_kwargs(self, identifier: int | UUID) -> dict[str, str | int]:
+    def _lookup_kwargs(self, identifier: EntityIdentifier) -> dict[str, str | int]:
         """Return lookup kwargs for a PK or UUID identifier.
 
         :param identifier: The identifier of the entity to retrieve.
-        :type identifier: int | UUID
+        :type identifier: EntityIdentifier
         :return: A dictionary with the appropriate lookup keyword and value.
         :rtype: dict[str, str | int]
         :raises ValueError: If the identifier is neither an int nor a UUID.

--- a/aiida_restapi/services/entity.py
+++ b/aiida_restapi/services/entity.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import typing as t
+from uuid import UUID
 
 from aiida import orm
 from aiida.common.exceptions import NotExistent
@@ -64,19 +65,29 @@ class EntityService(t.Generic[EntityType, EntityModelType]):
         """
         return self.entity_class.fields.keys()
 
-    def get_one(self, identifier: str | int) -> dict[str, t.Any]:
+    def get_one(self, identifier: int | UUID) -> dict[str, t.Any]:
         """Get an AiiDA entity by id.
 
-        :param identifier: The id of the entity to retrieve.
-        :type identifier: str | int
+        :param identifier: The identifier of the entity to retrieve.
+        :type identifier: int | UUID
         :return: The serialized AiiDA entity.
         :rtype: dict[str, t.Any]
         """
         try:
-            entity = self.entity_class.collection.get(**{self.entity_class.identity_field: identifier})
+            entity = self.entity_class.collection.get(**self._lookup_kwargs(identifier))
         except NotExistent as exception:
             raise NotExistent(f'{self.entity_class.__name__}<{identifier}> does not exist.') from exception
         return entity.serialize(minimal=True)
+
+    def load_one(self, identifier: int | UUID) -> EntityType:
+        """Load an entity using strict UUID-or-PK resolution.
+
+        :param identifier: The identifier of the entity to load.
+        :type identifier: int | UUID
+        :return: The loaded AiiDA entity.
+        :rtype: EntityType
+        """
+        return self.entity_class.collection.get(**self._lookup_kwargs(identifier))
 
     def get_many(self, query_params: QueryBuilderParams) -> PaginatedResults[dict[str, t.Any]]:
         """Get AiiDA entities with optional filtering, sorting, and/or pagination.
@@ -106,13 +117,13 @@ class EntityService(t.Generic[EntityType, EntityModelType]):
 
     def get_related_one(
         self,
-        identifier: str | int,
+        identifier: int | UUID,
         related_type: type[orm.Entity],
     ) -> dict[str, t.Any]:
         """Get a related foreign entity of an entity.
 
-        :param identifier: The id of the entity to retrieve the foreign entity for.
-        :type identifier: str | int
+        :param identifier: The identifier of the entity to retrieve the foreign entity for.
+        :type identifier: int | UUID
         :param related_type: The related AiiDA ORM entity class to retrieve.
         :type related_type: type[orm.Entity]
         :return: The related foreign entity.
@@ -122,7 +133,7 @@ class EntityService(t.Generic[EntityType, EntityModelType]):
             orm.QueryBuilder()
             .append(
                 self.entity_class,
-                filters={self.entity_class.identity_field: identifier},
+                filters=self._lookup_kwargs(identifier),
                 tag='entity',
             )
             .append(
@@ -147,14 +158,14 @@ class EntityService(t.Generic[EntityType, EntityModelType]):
 
     def get_related_many(
         self,
-        identifier: str | int,
+        identifier: int | UUID,
         related_type: type[orm.Entity],
         query_params: QueryBuilderParams,
     ) -> PaginatedResults[dict[str, t.Any]]:
         """Get related foreign entities of an entity.
 
-        :param identifier: The id of the entity to retrieve the foreign entities for.
-        :type identifier: str | int
+        :param identifier: The identifier of the entity to retrieve the foreign entities for.
+        :type identifier: int | UUID
         :param related_type: The related AiiDA ORM entity class to retrieve.
         :type related_type: type[orm.Entity]
         :param query_params: The query parameters, including filters, order_by, page_size, and page.
@@ -169,7 +180,7 @@ class EntityService(t.Generic[EntityType, EntityModelType]):
             )
             .append(
                 self.entity_class,
-                filters={self.entity_class.identity_field: identifier},
+                filters=self._lookup_kwargs(identifier),
                 tag='entity',
             )
             .append(
@@ -198,18 +209,18 @@ class EntityService(t.Generic[EntityType, EntityModelType]):
             data=[next(iter(result.values())) for result in results],
         )
 
-    def get_field(self, identifier: str | int, field: str) -> t.Any:
+    def get_field(self, identifier: int | UUID, field: str) -> t.Any:
         """Get a specific field of an entity.
 
-        :param identifier: The id of the entity to retrieve the extras for.
-        :type identifier: str | int
+        :param identifier: The identifier of the entity to retrieve the extras for.
+        :type identifier: int | UUID
         :param field: The specific field to retrieve.
         :type field: str
         :return: The value of the specified field.
         :rtype: t.Any
         """
         qb = self.entity_class.collection.query(
-            filters={self.entity_class.identity_field: identifier},
+            filters=self._lookup_kwargs(identifier),
             project=[field],
         )
 
@@ -234,19 +245,34 @@ class EntityService(t.Generic[EntityType, EntityModelType]):
         entity = self.entity_class.from_model(model).store()
         return entity.serialize(minimal=True)
 
-    def update(self, identifier: str | int, model: EntityModelType) -> dict[str, t.Any]:
+    def update(self, identifier: int | UUID, model: EntityModelType) -> dict[str, t.Any]:
         """Update an existing AiiDA entity.
 
-        :param identifier: The id of the entity to update.
-        :type identifier: str | int
+        :param identifier: The identifier of the entity to update.
+        :type identifier: int | UUID
         :param model: The Pydantic model of the entity to update.
         :type model: EntityModelType
         :return: The updated and stored AiiDA `Entity` instance.
         :rtype: dict[str, t.Any]
         """
-        entity = self.entity_class.collection.get(**{self.entity_class.identity_field: identifier})
+        entity = self.entity_class.collection.get(**self._lookup_kwargs(identifier))
         self._apply_update(entity, model)
         return entity.serialize(minimal=True)
+
+    def _lookup_kwargs(self, identifier: int | UUID) -> dict[str, str | int]:
+        """Return lookup kwargs for a PK or UUID identifier.
+
+        :param identifier: The identifier of the entity to retrieve.
+        :type identifier: int | UUID
+        :return: A dictionary with the appropriate lookup keyword and value.
+        :rtype: dict[str, str | int]
+        :raises ValueError: If the identifier is neither an int nor a UUID.
+        """
+        if isinstance(identifier, int):
+            return {'pk': identifier}
+        if isinstance(identifier, UUID):
+            return {'uuid': str(identifier)}
+        raise ValueError(f'Invalid identifier type: {type(identifier)}. Must be PK (int) or UUID.')
 
     def _get_projections(self, orm_class: type[orm.Entity] | None = None) -> list[str]:
         """Get the list of projections to use when querying the AiiDA entity.

--- a/aiida_restapi/services/node.py
+++ b/aiida_restapi/services/node.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import typing as t
+from uuid import UUID
 
 from aiida import orm
 from aiida.common import EntryPointError, exceptions
@@ -85,15 +86,16 @@ class NodeService(EntityService[NodeType, NodeModelType]):
 
         return all_formats
 
-    def get_repository_metadata(self, uuid: str) -> dict[str, dict]:
+    def get_repository_metadata(self, identifier: int | UUID) -> dict[str, dict]:
         """Get the repository metadata of a node.
 
-        :param uuid: The uuid of the node to retrieve the repository metadata for.
-        :type uuid: str
+        :param identifier: The identifier of the node to retrieve metadata for.
+        :type identifier: int | UUID
         :return: A dictionary with the repository file metadata.
         :rtype: dict[str, dict]
         """
-        node = self.entity_class.collection.get(uuid=uuid)
+        node = self.entity_class.collection.get(**self._lookup_kwargs(identifier))
+        node_identifier = node.uuid
         total_size = 0
 
         def get_metadata(objects: list[File], path: str | None = None) -> dict[str, dict]:
@@ -126,7 +128,7 @@ class NodeService(EntityService[NodeType, NodeModelType]):
                         'binary': binary,
                         'size': size,
                         'hash': node.base.repository.get_object(obj_name).serialize()['k'],
-                        'download': f'{API_CONFIG["PREFIX"]}/nodes/{uuid}/repo/contents?filename={obj_name}',
+                        'download': f'{API_CONFIG["PREFIX"]}/nodes/{node_identifier}/repo/contents?filename={obj_name}',
                     }
                     total_size += size
 
@@ -139,21 +141,21 @@ class NodeService(EntityService[NodeType, NodeModelType]):
                 'type': 'FILE',
                 'binary': True,
                 'size': total_size,
-                'download': f'{API_CONFIG["PREFIX"]}/nodes/{uuid}/repo/contents',
+                'download': f'{API_CONFIG["PREFIX"]}/nodes/{node_identifier}/repo/contents',
             }
 
         return metadata
 
     def get_links(
         self,
-        uuid: str,
+        identifier: int | UUID,
         direction: t.Literal['incoming', 'outgoing'],
         query_params: QueryBuilderParams = QueryBuilderParams(),
     ) -> PaginatedResults[dict[str, t.Any]]:
         """Get the incoming links of a node.
 
-        :param uuid: The uuid of the node to retrieve the incoming links for.
-        :type uuid: str
+        :param identifier: The identifier of the node to retrieve links for.
+        :type identifier: int | UUID
         :param query_params: The query parameters for filtering, sorting, and pagination.
         :type query_params: QueryBuilderParams
         :param direction: Specify whether to retrieve incoming or outgoing links.
@@ -161,6 +163,9 @@ class NodeService(EntityService[NodeType, NodeModelType]):
         :return: The paginated requested linked nodes.
         :rtype: PaginatedResults
         """
+        node = self.entity_class.collection.get(**self._lookup_kwargs(identifier))
+        node_uuid = node.uuid
+
         qb = (
             orm.QueryBuilder(
                 limit=query_params.page_size,
@@ -174,7 +179,7 @@ class NodeService(EntityService[NodeType, NodeModelType]):
             )
             .append(
                 self.entity_class,
-                filters={self.entity_class.identity_field: uuid},
+                filters={'uuid': node_uuid},
                 joining_keyword=f'with_{direction}',
                 joining_value='link',
                 edge_project=['label', 'type'],
@@ -186,7 +191,6 @@ class NodeService(EntityService[NodeType, NodeModelType]):
         qb.order_by([order_by])
 
         try:
-            node = self.entity_class.collection.get(uuid=uuid)
             total = len(getattr(node.base.links, f'get_{direction}')().all())
             results = qb.all()
         except Exception as exception:
@@ -196,9 +200,9 @@ class NodeService(EntityService[NodeType, NodeModelType]):
         for other_uuid, link_label, link_type in results:
             if direction == 'incoming':
                 source_uuid = other_uuid
-                target_uuid = uuid
+                target_uuid = node_uuid
             else:
-                source_uuid = uuid
+                source_uuid = node_uuid
                 target_uuid = other_uuid
             data.append(
                 {

--- a/aiida_restapi/services/node.py
+++ b/aiida_restapi/services/node.py
@@ -1,4 +1,4 @@
-"""REST API node repository."""
+"""REST API node service."""
 
 from __future__ import annotations
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,7 +113,7 @@ def default_computers():
         scheduler_type='core.pbspro',
     ).store()
 
-    return [comp_1.pk, comp_2.pk]
+    return [comp_1.uuid, comp_2.uuid]
 
 
 @pytest.fixture(scope='function')

--- a/tests/test_computers.py
+++ b/tests/test_computers.py
@@ -38,7 +38,21 @@ def test_get_computer(client: TestClient, default_computers: list[int | None]):
         assert response.status_code == 200
 
 
+def test_get_computer_by_pk(client: TestClient):
+    """Test retrieving a computer by PK."""
+    computer = orm.Computer(
+        label='test_computer_pk',
+        hostname='localhost',
+        transport_type='core.local',
+        scheduler_type='core.direct',
+    ).store()
+    response = client.get(f'/computers/{computer.pk}')
+    assert response.status_code == 200
+    assert response.json()['data']['id'] == str(computer.pk)
+
+
 def test_get_computer_metadata(client: TestClient):
+    """Test retrieving the metadata of a single computer."""
     metadata = {
         'workdir': '/tmp/aiida',
         'minimum_scheduler_poll_interval': 15,

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -38,6 +38,20 @@ def test_get_group(client: TestClient, default_groups: list[str]):
         assert response.status_code == 200
 
 
+def test_get_group_by_pk(client: TestClient):
+    """Test retrieving a group by PK on UUID route."""
+    group = orm.Group(label='test_group_pk').store()
+    response = client.get(f'/groups/{group.pk}')
+    assert response.status_code == 200
+    assert response.json()['data']['id'] == group.uuid
+
+
+def test_get_group_invalid_identifier(client: TestClient):
+    """Test invalid identifier format returns 422."""
+    response = client.get('/groups/not-a-uuid-or-int')
+    assert response.status_code == 422
+
+
 def test_get_group_user(client: TestClient):
     """Test retrieving the user of a single group."""
     group = orm.Group(label='test_group_user').store()

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -39,7 +39,7 @@ def test_get_group(client: TestClient, default_groups: list[str]):
 
 
 def test_get_group_by_pk(client: TestClient):
-    """Test retrieving a group by PK on UUID route."""
+    """Test retrieving a group by PK."""
     group = orm.Group(label='test_group_pk').store()
     response = client.get(f'/groups/{group.pk}')
     assert response.status_code == 200

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -238,6 +238,20 @@ def test_get_node(client: TestClient, default_nodes: list[str | None]):
     }
 
 
+def test_get_node_by_pk(client: TestClient):
+    """Test retrieving a node by PK on UUID route."""
+    node = orm.Int(value=11).store()
+    response = client.get(f'/nodes/{node.pk}')
+    assert response.status_code == 200
+    assert response.json()['data']['id'] == node.uuid
+
+
+def test_get_node_invalid_identifier(client: TestClient):
+    """Test invalid identifier format returns 422."""
+    response = client.get('/nodes/not-a-uuid-or-int')
+    assert response.status_code == 422
+
+
 def test_get_node_user(client: TestClient):
     """Test retrieving the user of a single node."""
     node = orm.Int(value=5).store()

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -239,7 +239,7 @@ def test_get_node(client: TestClient, default_nodes: list[str | None]):
 
 
 def test_get_node_by_pk(client: TestClient):
-    """Test retrieving a node by PK on UUID route."""
+    """Test retrieving a node by PK."""
     node = orm.Int(value=11).store()
     response = client.get(f'/nodes/{node.pk}')
     assert response.status_code == 200
@@ -260,7 +260,7 @@ def test_get_node_user(client: TestClient):
     assert response.json()['data']['attributes']['email'] == node.user.email
 
 
-def test_get_node_computer(client: TestClient, default_computers: list[int | None]):
+def test_get_node_computer(client: TestClient, default_computers: list[str]):
     """Test retrieving the computer of a single node."""
     computer = orm.load_computer(default_computers[0])
     node = orm.Int(value=5, computer=computer).store()
@@ -416,15 +416,16 @@ def test_create_node_constructor_not_supported(client: TestClient):
 
 
 @pytest.mark.anyio
-async def test_create_code(async_client: AsyncClient, default_computers: list[int | None]):
+async def test_create_code(async_client: AsyncClient, default_computers: list[str]):
     """Test creating a new Code."""
     for comp_id in default_computers:
+        computer = orm.load_computer(comp_id)
         response = await async_client.post(
             '/nodes',
             json={
                 'node_type': 'data.core.code.installed.InstalledCode.',
                 'label': 'test_code',
-                'computer': comp_id,
+                'computer': computer.pk,
                 'attributes': {
                     'filepath_executable': '/bin/true',
                 },
@@ -707,7 +708,6 @@ def test_create_node_wrong_value(client: TestClient, node_type: str, value: t.An
     assert response.status_code == 422, response.content
 
 
-@pytest.mark.usefixtures('default_computers')
 def test_create_unknown_entry_point(client: TestClient):
     """Test error message when specifying unknown ``entry_point``."""
     response = client.post(
@@ -720,7 +720,6 @@ def test_create_unknown_entry_point(client: TestClient):
     assert response.status_code == 422, response.content
 
 
-@pytest.mark.usefixtures('default_computers')
 def test_create_additional_attribute(client: TestClient):
     """Test adding additional properties are rejected."""
     response = client.post(


### PR DESCRIPTION
This PR provides PK support (in addition to UUID) for all `/entity/{identifier}/...` endpoints, where appropriate.
This is done via a global `EntityIdentifier` type var. Computers router is aligned to this as well (has UUID, but was only accepting PK). Users router is handled separately due to the lack of UUID on AiiDA User entities - see https://github.com/aiidateam/aiida-core/issues/6174)

Closes #120 